### PR TITLE
[FE] 회원가입, 로그인 페이지 UI & mock API 구성

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -18,7 +18,7 @@ const router = createBrowserRouter(
   createRoutesFromElements(
     <>
       <Route path="/auth" element={<AuthPage />}>
-        <Route path="login" element={<LoginPage />} />
+        <Route index element={<LoginPage />} />
         <Route path="signup" element={<SignupPage />} />
       </Route>
 

--- a/fe/src/api/index.ts
+++ b/fe/src/api/index.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+const instance = axios.create({
+  baseURL: "/api",
+  headers: { "Content-Type": "application/json" },
+});
+
+export const postSignup = async (loginId: string, password: string) => {
+  await instance.post("/auth/signup", { loginId, password });
+};
+
+export const postLogin = async (loginId: string, password: string) => {
+  return await instance.post("/auth/login", { loginId, password });
+};

--- a/fe/src/components/common/Button/constants.ts
+++ b/fe/src/components/common/Button/constants.ts
@@ -1,5 +1,5 @@
 export const SIZE = {
   S: { width: "128px", height: "40px" },
   M: { width: "184px", height: "48px" },
-  L: { width: "240px", height: "56px" },
+  L: { width: "320px", height: "56px" },
 };

--- a/fe/src/components/common/TextInput.tsx
+++ b/fe/src/components/common/TextInput.tsx
@@ -1,45 +1,41 @@
 import { useState } from "react";
 import styled from "styled-components";
 
-type TextInputProps = {
+interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   name: string;
   variant: "tall" | "short";
-  placeholderText?: string;
   hasError?: boolean;
   helpText?: string;
-};
+}
 
-export default function TextInput(props: TextInputProps) {
-  const { name, variant, placeholderText, hasError, helpText } = props;
-
-  const [content, setContent] = useState("");
+export default function TextInput({
+  name,
+  value,
+  variant,
+  hasError,
+  helpText,
+  ...props
+}: TextInputProps) {
   const [isFocused, setIsFocused] = useState(false);
 
   const isTallType = variant === "tall";
   const textInputState = isFocused ? "active" : hasError ? "error" : "enabled";
   const typingState = isFocused ? "onTyping" : "typed";
 
-  const onInputChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setContent(e.target.value);
-  };
-
   return (
     <StyledTextInput>
       <InputContainer $variant={variant} $state={textInputState}>
-        {isTallType && content && <Label htmlFor={name}>{name}</Label>}
+        {isTallType && value && <Label htmlFor={name}>{name}</Label>}
         {!isTallType && <Label htmlFor={name}>{name}</Label>}
         <Input
           id={name}
-          type="text"
-          value={content}
           $typingState={typingState}
-          placeholder={placeholderText || name}
-          onChange={onInputChanged}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
+          {...props}
         />
       </InputContainer>
-      {helpText && (
+      {hasError && helpText && (
         <HelpTextArea $state={textInputState}>{helpText}</HelpTextArea>
       )}
     </StyledTextInput>
@@ -104,7 +100,7 @@ const Input = styled.input<{
   $typingState: "onTyping" | "typed";
 }>`
   display: flex;
-  width: 80%;
+  width: 100%;
   color: ${({ $typingState, theme: { neutral } }) => {
     const type = {
       onTyping: neutral.text.strong,

--- a/fe/src/hooks/useInput.tsx
+++ b/fe/src/hooks/useInput.tsx
@@ -1,0 +1,34 @@
+import { useRef, useState } from "react";
+
+type useInputOptions = {
+  initialValue: string;
+  minLength?: number;
+  maxLength?: number;
+};
+
+export default function useInput({
+  initialValue,
+  maxLength,
+  minLength = 0,
+}: useInputOptions) {
+  const [value, setValue] = useState(initialValue);
+  const isValid = useRef(true);
+
+  const validate = (receivedValue: string) => {
+    isValid.current = receivedValue.length >= minLength;
+    setValue(receivedValue);
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const targetValue = e.target.value;
+    validate(targetValue);
+  };
+
+  return {
+    value,
+    onChange,
+    minLength,
+    maxLength,
+    isValid: isValid.current,
+  };
+}

--- a/fe/src/mocks/handlers.ts
+++ b/fe/src/mocks/handlers.ts
@@ -1,32 +1,71 @@
 import { rest } from "msw";
 
+const users: Record<string, string> = {};
+
+type AuthRequestBody = {
+  loginId: string;
+  password: string;
+};
+
 export const handlers = [
-  rest.post("/auth/login", (req, res, ctx) => {
-    return res(
-      // Respond with a 200 status code
-      ctx.status(200)
-    );
-  }),
+  rest.post("/api/auth/signup", async (req, res, ctx) => {
+    const { loginId, password } = await req.json<AuthRequestBody>();
+    const isExist = users[loginId];
+    users[loginId] = password;
 
-  rest.get("/user", (req, res, ctx) => {
-    // Check if the user is authenticated in this session
-    const isAuthenticated = true;
-
-    if (!isAuthenticated) {
-      // If not authenticated, respond with a 403 error
+    if (isExist) {
       return res(
-        ctx.status(403),
+        ctx.status(400),
         ctx.json({
-          errorMessage: "Not authorized",
+          errorCode: "DUPLICATED_LOGIN_ID",
+          message: "중복된 로그인 아이디가 존재합니다.",
         })
       );
     }
 
-    // If authenticated, return a mocked user details
+    return res(ctx.status(200));
+  }),
+
+  rest.post("/api/auth/login", async (req, res, ctx) => {
+    const { loginId, password } = await req.json<AuthRequestBody>();
+    const isExist = users[loginId];
+    const isCorrectPassword = users[loginId] === password;
+
+    if (!isExist) {
+      return res(
+        ctx.status(404),
+        ctx.json({
+          errorCode: "USER_NOT_FOUND",
+          message: "존재하지 않는 회원입니다.",
+        })
+      );
+    }
+
+    if (!isCorrectPassword) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: "FAILED_LOGIN",
+          message: "비밀번호가 일치하지 않습니다.",
+        })
+      );
+    }
+
+    // TODO: 만료된 토큰에 대한 응답 처리
+
     return res(
       ctx.status(200),
       ctx.json({
-        username: "admin",
+        token: {
+          tokenType: "bearer",
+          accessToken: "q13t302hv2ht0",
+          expiresIn: 48000000,
+        },
+        user: {
+          username: "admin",
+          userProfileSrc:
+            "https://avatars.githubusercontent.com/u/48426991?v=4",
+        },
       })
     );
   }),

--- a/fe/src/pages/AuthPage.tsx
+++ b/fe/src/pages/AuthPage.tsx
@@ -18,6 +18,9 @@ export const StyledAuthPage = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  width: 100vw;
+  height: 100vh;
+  background: ${({ theme: { neutral } }) => neutral.surface.default};
 
   .login-area {
     display: flex;

--- a/fe/src/pages/AuthPage.tsx
+++ b/fe/src/pages/AuthPage.tsx
@@ -1,10 +1,45 @@
+import Logo from "@components/common/Logo";
 import { Outlet } from "react-router-dom";
+import styled from "styled-components";
 
 export default function AuthPage() {
   return (
-    <div>
-      <h1>Auth</h1>
-      <Outlet />
-    </div>
+    <StyledAuthPage>
+      <Logo size="large" />
+      <div className="login-area">
+        <Outlet />
+      </div>
+    </StyledAuthPage>
   );
 }
+
+export const StyledAuthPage = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  .login-area {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 320px;
+    gap: 24px;
+    margin: 48px 0;
+  }
+
+  .github-login-btn {
+    font: ${({ theme: { font } }) => font.availableMD20};
+  }
+
+  .or {
+    font: ${({ theme: { font } }) => font.displayMD16};
+    color: ${({ theme: { neutral } }) => neutral.text.weak};
+  }
+
+  .change-auth-btn {
+    font: ${({ theme: { font } }) => font.displayMD16};
+    color: ${({ theme: { neutral } }) => neutral.text.default};
+  }
+`;

--- a/fe/src/pages/AuthPage.tsx
+++ b/fe/src/pages/AuthPage.tsx
@@ -42,4 +42,9 @@ export const StyledAuthPage = styled.div`
     font: ${({ theme: { font } }) => font.displayMD16};
     color: ${({ theme: { neutral } }) => neutral.text.default};
   }
+
+  .error-message {
+    font: ${({ theme: { font } }) => font.displayMD16};
+    color: ${({ theme: { danger } }) => danger.text.default};
+  }
 `;

--- a/fe/src/pages/LoginPage.tsx
+++ b/fe/src/pages/LoginPage.tsx
@@ -1,3 +1,74 @@
+import Button from "@components/common/Button";
+import TextInput from "@components/common/TextInput";
+import useInput from "@hooks/useInput";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
 export default function LoginPage() {
-  return <div>나는 로그인!</div>;
+  const { isValid: isValidUsername, ...username } = useInput({
+    initialValue: "",
+    maxLength: 16,
+    minLength: 6,
+  });
+  const { isValid: isValidPassword, ...password } = useInput({
+    initialValue: "",
+    maxLength: 16,
+    minLength: 6,
+  });
+
+  return (
+    <>
+      <Button variant="outline" size="L" className="github-login-btn">
+        GitHub 계정으로 로그인
+      </Button>
+      <span className="or">or</span>
+      <AuthForm>
+        <TextInput
+          name="아이디"
+          variant="tall"
+          hasError={!isValidUsername}
+          placeholder="아이디"
+          helpText="아이디는 최소 6자리여야 해요!"
+          {...username}
+        />
+        <TextInput
+          name="비밀번호"
+          variant="tall"
+          hasError={!isValidPassword}
+          placeholder="비밀번호"
+          helpText="비밀번호는 최소 6자리여야 해요!"
+          type="password"
+          {...password}
+        />
+        <Button
+          variant="container"
+          size="L"
+          className="login-btn"
+          disabled={!isValidUsername || !isValidPassword}
+          type="submit"
+          onClick={(e) => {
+            e.preventDefault();
+            console.log("로그인");
+          }}>
+          아이디로 로그인
+        </Button>
+      </AuthForm>
+      <Link to="/auth/signup">
+        <Button variant="ghost" size="M" className="change-auth-btn">
+          아직 계정이 없으신가요? 회원가입
+        </Button>
+      </Link>
+    </>
+  );
 }
+
+export const AuthForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 12px;
+
+  .login-btn {
+    font: ${({ theme: { font } }) => font.availableMD20};
+  }
+`;

--- a/fe/src/pages/LoginPage.tsx
+++ b/fe/src/pages/LoginPage.tsx
@@ -1,6 +1,9 @@
 import Button from "@components/common/Button";
 import TextInput from "@components/common/TextInput";
 import useInput from "@hooks/useInput";
+import { postLogin } from "api";
+import { AxiosError } from "axios";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
@@ -15,6 +18,21 @@ export default function LoginPage() {
     maxLength: 16,
     minLength: 6,
   });
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      await postLogin(username.value, password.value);
+      // accessToken을 받아서 axios의 header에 넣어주는 로직이 필요함
+    } catch (error) {
+      if (error instanceof AxiosError && error.response) {
+        const { message } = error.response.data;
+        setErrorMessage(message);
+      }
+    }
+  };
 
   return (
     <>
@@ -22,7 +40,7 @@ export default function LoginPage() {
         GitHub 계정으로 로그인
       </Button>
       <span className="or">or</span>
-      <AuthForm>
+      <AuthForm onSubmit={onSubmit}>
         <TextInput
           name="아이디"
           variant="tall"
@@ -40,16 +58,13 @@ export default function LoginPage() {
           type="password"
           {...password}
         />
+        {errorMessage && <p className="error-message">{errorMessage}</p>}
         <Button
           variant="container"
           size="L"
           className="login-btn"
           disabled={!isValidUsername || !isValidPassword}
-          type="submit"
-          onClick={(e) => {
-            e.preventDefault();
-            console.log("로그인");
-          }}>
+          type="submit">
           아이디로 로그인
         </Button>
       </AuthForm>

--- a/fe/src/pages/SignupPage.tsx
+++ b/fe/src/pages/SignupPage.tsx
@@ -1,3 +1,59 @@
-export default function AuthPage() {
-  return <div>Signup Page</div>;
+import Button from "@components/common/Button";
+import TextInput from "@components/common/TextInput";
+import useInput from "@hooks/useInput";
+import { Link } from "react-router-dom";
+import { AuthForm } from "./LoginPage";
+
+export default function SignupPage() {
+  const { isValid: isValidUsername, ...username } = useInput({
+    initialValue: "",
+    maxLength: 16,
+    minLength: 6,
+  });
+  const { isValid: isValidPassword, ...password } = useInput({
+    initialValue: "",
+    maxLength: 16,
+    minLength: 6,
+  });
+
+  return (
+    <>
+      <AuthForm>
+        <TextInput
+          name="아이디"
+          variant="tall"
+          hasError={!isValidUsername}
+          placeholder="아이디"
+          helpText="아이디는 최소 6자리여야 해요!"
+          {...username}
+        />
+        <TextInput
+          name="비밀번호"
+          variant="tall"
+          hasError={!isValidPassword}
+          placeholder="비밀번호"
+          helpText="비밀번호는 최소 6자리여야 해요!"
+          type="password"
+          {...password}
+        />
+        <Button
+          variant="container"
+          size="L"
+          className="login-btn"
+          disabled={!isValidUsername || !isValidPassword}
+          type="submit"
+          onClick={(e) => {
+            e.preventDefault();
+            console.log("회원가입");
+          }}>
+          회원가입
+        </Button>
+      </AuthForm>
+      <Link to="/auth">
+        <Button variant="ghost" size="M" className="change-auth-btn">
+          이미 계정이 있으신가요? 로그인
+        </Button>
+      </Link>
+    </>
+  );
 }

--- a/fe/src/pages/SignupPage.tsx
+++ b/fe/src/pages/SignupPage.tsx
@@ -1,6 +1,9 @@
 import Button from "@components/common/Button";
 import TextInput from "@components/common/TextInput";
 import useInput from "@hooks/useInput";
+import { postSignup } from "api";
+import { AxiosError } from "axios";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { AuthForm } from "./LoginPage";
 
@@ -15,10 +18,24 @@ export default function SignupPage() {
     maxLength: 16,
     minLength: 6,
   });
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      await postSignup(username.value, password.value);
+    } catch (error) {
+      if (error instanceof AxiosError && error.response) {
+        const { message } = error.response.data;
+        setErrorMessage(message);
+      }
+    }
+  };
 
   return (
     <>
-      <AuthForm>
+      <AuthForm onSubmit={onSubmit}>
         <TextInput
           name="아이디"
           variant="tall"
@@ -36,16 +53,13 @@ export default function SignupPage() {
           type="password"
           {...password}
         />
+        {errorMessage && <p className="error-message">{errorMessage}</p>}
         <Button
           variant="container"
           size="L"
           className="login-btn"
           disabled={!isValidUsername || !isValidPassword}
-          type="submit"
-          onClick={(e) => {
-            e.preventDefault();
-            console.log("회원가입");
-          }}>
+          type="submit">
           회원가입
         </Button>
       </AuthForm>

--- a/fe/src/styles/GlobalStyle.tsx
+++ b/fe/src/styles/GlobalStyle.tsx
@@ -78,13 +78,4 @@ export default createGlobalStyle`
       box-sizing: inherit;
     }
   }
-
-  #root {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100vw;
-    height: 100vh;
-    background: ${({ theme: { neutral } }) => neutral.surface.default};
-  }
 `;

--- a/fe/src/styles/GlobalStyle.tsx
+++ b/fe/src/styles/GlobalStyle.tsx
@@ -62,6 +62,11 @@ export default createGlobalStyle`
     margin: 0;
   }
 
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
   html {
     box-sizing: border-box;
   }
@@ -72,5 +77,14 @@ export default createGlobalStyle`
     &::after {
       box-sizing: inherit;
     }
+  }
+
+  #root {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100vw;
+    height: 100vh;
+    background: ${({ theme: { neutral } }) => neutral.surface.default};
   }
 `;


### PR DESCRIPTION
## Issues
- #30 

## What is this PR? 👓
- AuthPage(Login/Signup) UI 구현
- /login, /signup mock API 구성 & 요청

## Key changes 🔑
- Auth index Page를 Login으로 설정
- useInput Hooks 생성: 이후 확장성을 고려하여 useInput hook으로 validate 로직 분리
- Login & Signup page 분리

## To reviewers 👋
- Login & Signup AuthForm 로직이 거의 중복이라 요청하는 API만 달라서 합치는게 나을지 고민중이에요.
- 아직 Response accessToken, api 함수 구현은 진행중입니다!