### PR TITLE
[BE] 토큰에서 사용자 정보 추출

### DIFF
--- a/backend/src/main/java/kr/codesquad/issuetracker/domain/AuthenticationContext.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/domain/AuthenticationContext.java
@@ -1,0 +1,18 @@
+package kr.codesquad.issuetracker.domain;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+import lombok.Getter;
+
+@Component
+@Getter
+@RequestScope
+public class AuthenticationContext {
+
+	private String principal;
+
+	public void setPrincipal(String principal) {
+		this.principal = principal;
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Import;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kr.codesquad.config.JwtConfig;
+import kr.codesquad.issuetracker.domain.AuthenticationContext;
 import kr.codesquad.issuetracker.infrastructure.security.hash.PasswordEncoder;
 import kr.codesquad.issuetracker.infrastructure.security.hash.SHA256;
 import kr.codesquad.issuetracker.infrastructure.security.jwt.JwtProvider;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
 	private final JwtProvider jwtProvider;
+	private final AuthenticationContext authenticationContext;
 	private final ObjectMapper objectMapper;
 
 	@Bean
@@ -31,7 +33,7 @@ public class SecurityConfig {
 	@Bean
 	public FilterRegistrationBean<JwtFilter> jwtFilter() {
 		FilterRegistrationBean<JwtFilter> jwtFilter = new FilterRegistrationBean<>();
-		jwtFilter.setFilter(new JwtFilter(jwtProvider));
+		jwtFilter.setFilter(new JwtFilter(jwtProvider, authenticationContext));
 		jwtFilter.addUrlPatterns("/api/*");
 		jwtFilter.setOrder(2);
 		return jwtFilter;

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/config/WebConfig.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/config/WebConfig.java
@@ -1,0 +1,22 @@
+package kr.codesquad.issuetracker.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import kr.codesquad.issuetracker.presentation.auth.AuthPrincipalArgumentResolver;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	private final AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(authPrincipalArgumentResolver);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/security/jwt/JwtProvider.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/security/jwt/JwtProvider.java
@@ -50,4 +50,14 @@ public class JwtProvider {
 			throw new ApplicationException(ErrorCode.INVALID_JWT);
 		}
 	}
+
+	public String extractUserId(final String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(secretKey)
+			.build()
+			.parseClaimsJws(token)
+			.getBody()
+			.get("userId")
+			.toString();
+	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/auth/AuthPrincipal.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/auth/AuthPrincipal.java
@@ -1,0 +1,11 @@
+package kr.codesquad.issuetracker.presentation.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthPrincipal {
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/auth/AuthPrincipalArgumentResolver.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/auth/AuthPrincipalArgumentResolver.java
@@ -1,0 +1,30 @@
+package kr.codesquad.issuetracker.presentation.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import kr.codesquad.issuetracker.domain.AuthenticationContext;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class AuthPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final AuthenticationContext authenticationContext;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(AuthPrincipal.class)
+			&& parameter.getParameterType().equals(Integer.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+		return Integer.valueOf(authenticationContext.getPrincipal());
+	}
+}

--- a/backend/src/test/java/kr/codesquad/issuetracker/infrastructure/security/jwt/JwtProviderTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/infrastructure/security/jwt/JwtProviderTest.java
@@ -1,7 +1,6 @@
 package kr.codesquad.issuetracker.infrastructure.security.jwt;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -9,8 +8,6 @@ import java.util.Date;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -32,15 +29,7 @@ class JwtProviderTest {
 		String token = jwtProvider.createToken("1");
 
 		// then
-		Jws<Claims> claimsJws = Jwts.parserBuilder()
-			.setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
-			.build()
-			.parseClaimsJws(token);
-
-		assertAll(
-			() -> assertThat(token).isNotNull().isNotEmpty(),
-			() -> assertThat(String.valueOf(claimsJws.getBody().get("userId"))).isEqualTo("1")
-		);
+		assertThat(token).isNotNull().isNotEmpty();
 	}
 
 	@DisplayName("유효하지 않은 토큰이면 예외가 발생한다.")
@@ -70,5 +59,18 @@ class JwtProviderTest {
 		assertThatThrownBy(() -> jwtProvider.validateToken(token))
 			.isInstanceOf(ApplicationException.class)
 			.extracting("errorCode").isEqualTo(ErrorCode.EXPIRED_JWT);
+	}
+
+	@DisplayName("토큰에서 userId를 추출한다.")
+	@Test
+	void givenToken_thenExtractUserId() {
+		// given
+		String token = jwtProvider.createToken("13");
+
+		// when
+		String userId = jwtProvider.extractUserId(token);
+
+		// then
+		assertThat(userId).isEqualTo("13");
 	}
 }

--- a/backend/src/test/java/kr/codesquad/issuetracker/infrastructure/security/jwt/JwtProviderTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/infrastructure/security/jwt/JwtProviderTest.java
@@ -29,7 +29,7 @@ class JwtProviderTest {
 		String token = jwtProvider.createToken("1");
 
 		// then
-		assertThat(token).isNotNull().isNotEmpty();
+		assertThat(token).isNotBlank();
 	}
 
 	@DisplayName("유효하지 않은 토큰이면 예외가 발생한다.")


### PR DESCRIPTION
## Issues
- #47 

## What is this PR? 👓
JWT에서 사용자 정보 `userId`를 추출하는 로직을 구현한 PR입니다.

## Key changes 🔑
- JWT에서 `userId`를 추출합니다.
- 해당 `userId`를 `RequestScope`을 가진 `AuthenticationContext`빈에 담습니다.
- `AuthenticationContext`에 담긴 `userId(user_account 테이블의 PK)`를 여러 곳에서 사용할 것이기 때문에 `argumentResolver`를 통해 애노테이션으로 쉽게 가져올 수 있도록 구현했습니다.
- 테스트코드 작성

## To reviewers 👋
정상적으로 토큰에서 userId를 추출하는지 확인해주세요!
테스트코드가 올바른지 확인해주세요!
