### PR TITLE
[BE] 이슈 등록

### DIFF
--- a/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
@@ -1,12 +1,20 @@
 package kr.codesquad.issuetracker.application;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.codesquad.issuetracker.domain.Issue;
+import kr.codesquad.issuetracker.domain.IssueAssignee;
+import kr.codesquad.issuetracker.domain.IssueLabel;
+import kr.codesquad.issuetracker.infrastructure.persistence.IssueAssigneeRepository;
+import kr.codesquad.issuetracker.infrastructure.persistence.IssueLabelRepository;
 import kr.codesquad.issuetracker.infrastructure.persistence.IssueRepository;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
+import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -14,6 +22,31 @@ import lombok.RequiredArgsConstructor;
 public class IssueService {
 
 	private final IssueRepository issueRepository;
+	private final IssueAssigneeRepository assigneeRepository;
+	private final IssueLabelRepository issueLabelRepository;
+
+	@Transactional
+	public Integer register(Integer authorId, IssueRegisterRequest request) {
+		Integer issueId = issueRepository.save(new Issue(request.getTitle(),
+			request.getContent(),
+			Boolean.TRUE,
+			authorId,
+			request.getMilestone().orElse(null)));
+
+		request.getAssignees().ifPresent(assigneeIds ->
+			assigneeRepository.saveAll(toEntityList(assigneeIds, id -> new IssueAssignee(issueId, id))));
+
+		request.getLabels().ifPresent(labelIds ->
+			issueLabelRepository.saveAll(toEntityList(labelIds, id -> new IssueLabel(issueId, id))));
+
+		return issueId;
+	}
+
+	private <T> List<T> toEntityList(List<Integer> ids, Function<Integer, T> mapper) {
+		return ids.stream()
+			.map(mapper)
+			.collect(Collectors.toList());
+	}
 
 	@Transactional(readOnly = true)
 	public List<IssueSimpleMapper> findAll() {

--- a/backend/src/main/java/kr/codesquad/issuetracker/domain/Issue.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/domain/Issue.java
@@ -15,4 +15,12 @@ public class Issue {
 	private Boolean isDeleted;
 	private Integer userAccountId;
 	private Integer milestoneId;
+
+	public Issue(String title, String content, Boolean isOpen, Integer userAccountId, Integer milestoneId) {
+		this.title = title;
+		this.content = content;
+		this.isOpen = isOpen;
+		this.userAccountId = userAccountId;
+		this.milestoneId = milestoneId;
+	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/domain/IssueAssignee.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/domain/IssueAssignee.java
@@ -8,4 +8,9 @@ public class IssueAssignee {
 	private Integer id;
 	private Integer issueId;
 	private Integer userAccountId;
+
+	public IssueAssignee(Integer issueId, Integer userAccountId) {
+		this.issueId = issueId;
+		this.userAccountId = userAccountId;
+	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/domain/IssueLabel.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/domain/IssueLabel.java
@@ -8,4 +8,9 @@ public class IssueLabel {
 	private Integer id;
 	private Integer issueId;
 	private Integer labelId;
+
+	public IssueLabel(Integer issueId, Integer labelId) {
+		this.issueId = issueId;
+		this.labelId = labelId;
+	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueAssigneeRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueAssigneeRepository.java
@@ -1,0 +1,31 @@
+package kr.codesquad.issuetracker.infrastructure.persistence;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+
+import kr.codesquad.issuetracker.domain.IssueAssignee;
+
+@Repository
+public class IssueAssigneeRepository {
+
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+	private final SimpleJdbcInsert jdbcInsert;
+
+	public IssueAssigneeRepository(DataSource dataSource) {
+		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+		this.jdbcInsert = new SimpleJdbcInsert(dataSource)
+			.withTableName("issue_assignee")
+			.usingGeneratedKeyColumns("id")
+			.usingColumns("issue_id", "user_account_id");
+	}
+
+	public void saveAll(List<IssueAssignee> assignees) {
+		jdbcInsert.executeBatch(SqlParameterSourceUtils.createBatch(assignees));
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueLabelRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueLabelRepository.java
@@ -1,0 +1,31 @@
+package kr.codesquad.issuetracker.infrastructure.persistence;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+
+import kr.codesquad.issuetracker.domain.IssueLabel;
+
+@Repository
+public class IssueLabelRepository {
+
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+	private final SimpleJdbcInsert jdbcInsert;
+
+	public IssueLabelRepository(DataSource dataSource) {
+		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+		this.jdbcInsert = new SimpleJdbcInsert(dataSource)
+			.withTableName("issue_label")
+			.usingGeneratedKeyColumns("id")
+			.usingColumns("issue_id", "label_id");
+	}
+
+	public void saveAll(List<IssueLabel> issueLabels) {
+		jdbcInsert.executeBatch(SqlParameterSourceUtils.createBatch(issueLabels));
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueRepository.java
@@ -6,18 +6,26 @@ import java.util.List;
 import javax.sql.DataSource;
 
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
+import kr.codesquad.issuetracker.domain.Issue;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
 
 @Repository
 public class IssueRepository {
 
 	private final NamedParameterJdbcTemplate jdbcTemplate;
+	private final SimpleJdbcInsert jdbcInsert;
 
 	public IssueRepository(DataSource dataSource) {
 		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+		this.jdbcInsert = new SimpleJdbcInsert(dataSource)
+			.withTableName("issue")
+			.usingGeneratedKeyColumns("id")
+			.usingColumns("title", "is_open", "content", "user_account_id", "milestone_id");
 	}
 
 	public List<IssueSimpleMapper> findAll() {
@@ -50,5 +58,9 @@ public class IssueRepository {
 			rs.getString("milestone"),
 			rs.getString("assignee"),
 			rs.getTimestamp("created_at").toLocalDateTime());
+	}
+
+	public Integer save(Issue issue) {
+		return jdbcInsert.executeAndReturnKey(new BeanPropertySqlParameterSource(issue)).intValue();
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/IssueController.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/IssueController.java
@@ -2,13 +2,21 @@ package kr.codesquad.issuetracker.presentation;
 
 import java.util.List;
 
+import javax.validation.Valid;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import kr.codesquad.issuetracker.application.IssueService;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
+import kr.codesquad.issuetracker.presentation.auth.AuthPrincipal;
+import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
 import lombok.RequiredArgsConstructor;
 
 @RequestMapping("/api/issues")
@@ -21,5 +29,14 @@ public class IssueController {
 	@GetMapping
 	public ResponseEntity<List<IssueSimpleMapper>> findAll() {
 		return ResponseEntity.ok(issueService.findAll());
+	}
+
+	@PostMapping
+	public ResponseEntity<Void> register(@AuthPrincipal Integer userId,
+		@Valid @RequestBody IssueRegisterRequest request) {
+		Integer issueId = issueService.register(userId, request);
+		return ResponseEntity.status(HttpStatus.FOUND)
+			.header(HttpHeaders.LOCATION, "/api/issues/" + issueId)
+			.build();
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/IssueRegisterRequest.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/IssueRegisterRequest.java
@@ -1,0 +1,36 @@
+package kr.codesquad.issuetracker.presentation.request;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.validation.constraints.NotEmpty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class IssueRegisterRequest {
+
+	@NotEmpty(message = "이슈의 제목은 비워둘 수 없습니다.")
+	private String title;
+	private String content;
+	private List<Integer> assignees;
+	private List<Integer> labels;
+	private Integer milestone;
+
+	public Optional<List<Integer>> getAssignees() {
+		return Optional.ofNullable(assignees);
+	}
+
+	public Optional<List<Integer>> getLabels() {
+		return Optional.ofNullable(labels);
+	}
+
+	public Optional<Integer> getMilestone() {
+		return Optional.ofNullable(milestone);
+	}
+}
+

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/IssueRegisterRequest.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/IssueRegisterRequest.java
@@ -22,11 +22,17 @@ public class IssueRegisterRequest {
 	private Integer milestone;
 
 	public Optional<List<Integer>> getAssignees() {
-		return Optional.ofNullable(assignees);
+		if (assignees == null || assignees.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(assignees);
 	}
 
 	public Optional<List<Integer>> getLabels() {
-		return Optional.ofNullable(labels);
+		if (labels == null || labels.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(labels);
 	}
 
 	public Optional<Integer> getMilestone() {

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/IssueRegisterRequest.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/IssueRegisterRequest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class IssueRegisterRequest {
 
+	@Size(max = 45, message = "이슈의 제목은 45자를 넘을 수 없습니다.")
 	@NotEmpty(message = "이슈의 제목은 비워둘 수 없습니다.")
 	private String title;
 	private String content;

--- a/backend/src/test/java/kr/codesquad/issuetracker/acceptance/IssueAcceptanceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/acceptance/IssueAcceptanceTest.java
@@ -1,0 +1,56 @@
+package kr.codesquad.issuetracker.acceptance;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import io.restassured.RestAssured;
+import kr.codesquad.issuetracker.fixture.FixtureFactory;
+import kr.codesquad.issuetracker.infrastructure.security.jwt.JwtProvider;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class IssueAcceptanceTest {
+
+	@Autowired
+	private DatabaseInitializer databaseInitializer;
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	@BeforeEach
+	void setUp() {
+		databaseInitializer.truncateTables();
+	}
+
+	@DisplayName("이슈 등록에 성공한다.")
+	@Test
+	void registerIssueSuccess() {
+		// given
+		var given = RestAssured
+			.given().log().all()
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createToken("1"))
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.body(FixtureFactory.createIssueRegisterRequest("테스트코드 작성하기", List.of(1, 2), List.of(1, 2)));
+
+		// when
+		var response = given
+			.when()
+			.post("/api/issues")
+			.then().log().all()
+			.extract();
+
+		// then
+		assertAll(
+			() -> assertThat(response.statusCode()).isEqualTo(302),
+			() -> assertThat(response.header(HttpHeaders.LOCATION)).isEqualTo("/api/issues/1")
+		);
+	}
+}

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,10 +12,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import kr.codesquad.issuetracker.ApplicationTest;
 import kr.codesquad.issuetracker.acceptance.DatabaseInitializer;
+import kr.codesquad.issuetracker.fixture.FixtureFactory;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
+import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
 
 @ApplicationTest
 class IssueServiceTest {
+
 	@Autowired
 	private DatabaseInitializer databaseInitializer;
 
@@ -26,6 +28,25 @@ class IssueServiceTest {
 	@BeforeEach
 	void setUp() {
 		databaseInitializer.initTables();
+	}
+
+	@DisplayName("")
+	@Test
+	void registerIssueTest() {
+		// given
+		IssueRegisterRequest request = FixtureFactory
+			.createIssueRegisterRequest("프로젝트 세팅하기", List.of(1, 2), List.of(1, 2));
+
+		// when
+		issueService.register(1, request);
+
+		// then
+		List<IssueSimpleMapper> result = issueService.findAll();
+		assertAll(
+			() -> assertThat(result.get(0).getIssueNumber()).isEqualTo(4),
+			() -> assertThat(result.get(0).isOpen()).isTrue(),
+			() -> assertThat(result.get(0).getTitle()).isEqualTo("프로젝트 세팅하기")
+		);
 	}
 
 	@DisplayName("전체 이슈 목록을 조회할 수 있다.")

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
@@ -30,7 +30,7 @@ class IssueServiceTest {
 		databaseInitializer.initTables();
 	}
 
-	@DisplayName("")
+	@DisplayName("이슈 등록에 성공한다.")
 	@Test
 	void registerIssueTest() {
 		// given

--- a/backend/src/test/java/kr/codesquad/issuetracker/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/fixture/FixtureFactory.java
@@ -1,5 +1,8 @@
 package kr.codesquad.issuetracker.fixture;
 
+import java.util.List;
+
+import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
 import kr.codesquad.issuetracker.presentation.request.LoginRequest;
 import kr.codesquad.issuetracker.presentation.request.SignupRequest;
 
@@ -11,5 +14,16 @@ public class FixtureFactory {
 
 	public static LoginRequest createLoginRequest(String id, String pw) {
 		return new LoginRequest(id, pw);
+	}
+
+	public static IssueRegisterRequest createIssueRegisterRequest(String title,
+		List<Integer> assigneeIds, List<Integer> labelIds) {
+		return new IssueRegisterRequest(
+			title,
+			"프로젝트를 잘 설정해봅시다.",
+			assigneeIds,
+			labelIds,
+			1
+		);
 	}
 }

--- a/backend/src/test/java/kr/codesquad/issuetracker/presentation/ControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/presentation/ControllerTest.java
@@ -1,0 +1,44 @@
+package kr.codesquad.issuetracker.presentation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.codesquad.issuetracker.domain.AuthenticationContext;
+import kr.codesquad.issuetracker.infrastructure.config.SecurityConfig;
+import kr.codesquad.issuetracker.infrastructure.config.WebConfig;
+import kr.codesquad.issuetracker.infrastructure.security.jwt.JwtProvider;
+import kr.codesquad.issuetracker.presentation.filter.ExceptionHandlerFilter;
+import kr.codesquad.issuetracker.presentation.filter.JwtFilter;
+
+@Import({WebConfig.class, SecurityConfig.class, JwtProvider.class, AuthenticationContext.class})
+@WebMvcTest
+public class ControllerTest {
+
+	@Autowired
+	protected MockMvc mockMvc;
+	@Autowired
+	protected ObjectMapper objectMapper;
+	@Autowired
+	protected FilterRegistrationBean<JwtFilter> jwtFilter;
+	@Autowired
+	protected FilterRegistrationBean<ExceptionHandlerFilter> exceptionHandlerFilter;
+	@Autowired
+	protected JwtProvider jwtProvider;
+
+	@BeforeEach
+	void setUp(WebApplicationContext context) {
+		mockMvc = MockMvcBuilders
+			.webAppContextSetup(context)
+			.addFilter(exceptionHandlerFilter.getFilter())
+			.addFilter(jwtFilter.getFilter())
+			.build();
+	}
+}

--- a/backend/src/test/java/kr/codesquad/issuetracker/presentation/IssueControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/presentation/IssueControllerTest.java
@@ -1,0 +1,83 @@
+package kr.codesquad.issuetracker.presentation;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import kr.codesquad.issuetracker.application.IssueService;
+import kr.codesquad.issuetracker.fixture.FixtureFactory;
+import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
+
+@WebMvcTest(IssueController.class)
+class IssueControllerTest extends ControllerTest {
+
+	@MockBean
+	private IssueService issueService;
+
+	@Nested
+	class IssueRegisterTest {
+
+		@DisplayName("이슈 등록에 성공한다.")
+		@Test
+		void issueRegister() throws Exception {
+			// given
+			IssueRegisterRequest request = FixtureFactory.createIssueRegisterRequest("프로젝트 세팅하기", List.of(1, 2),
+				List.of(3, 4));
+			given(issueService.register(anyInt(), any(IssueRegisterRequest.class))).willReturn(1);
+
+			// when & then
+			mockMvc.perform(
+					post("/api/issues")
+						.contentType(MediaType.APPLICATION_JSON)
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createToken("1"))
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isFound())
+				.andExpect(header().stringValues("Location", "/api/issues/1"))
+				.andDo(print());
+		}
+
+		@DisplayName("권한이 없어 이슈 등록에 실패한다.")
+		@Test
+		void givenNoToken_thenResponse401() throws Exception {
+			IssueRegisterRequest request = FixtureFactory.createIssueRegisterRequest("프로젝트 세팅하기", List.of(1, 2),
+				List.of(3, 4));
+			given(issueService.register(anyInt(), any(IssueRegisterRequest.class))).willReturn(1);
+
+			// when & then
+			mockMvc.perform(
+					post("/api/issues")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isUnauthorized())
+				.andDo(print());
+		}
+
+		@DisplayName("유효하지 않은 요청으로 인해 이슈 등록에 실패한다.")
+		@Test
+		void givenInvalidIssueRegisterRequest_thenResponse400() throws Exception {
+			// given
+			IssueRegisterRequest request = FixtureFactory.createIssueRegisterRequest("", List.of(1, 2), List.of(3, 4));
+			given(issueService.register(anyInt(), any(IssueRegisterRequest.class))).willReturn(1);
+
+			// when & then
+			mockMvc.perform(
+					post("/api/issues")
+						.contentType(MediaType.APPLICATION_JSON)
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createToken("1"))
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andDo(print());
+		}
+	}
+}


### PR DESCRIPTION
## Issues
- #50 

## What is this PR? 👓
이슈 등록에 대한 PR입니다.

## Key changes 🔑
- 이슈 등록 기능 구현
  - 이슈 등록에 성공하면 `issue_assignee`, `issue_label` 테이블에도 INSERT 하도록 했습니다.
  - `assignees`, `labels`가 빈 리스트 혹은 null 로 올 수 있기 때문에 이를 위해 Optional을 사용했습니다.
- 테스트코드 작성

```json
{
    "title": "이슈 제목",
    "content": "이슈 내용", // nullable
    "assignees": null, // null 인 경우
    "labels": [], // 빈 리스트인 경우
    "milestone": 1 // nullable
}
```

## To reviewers 👋
- 이슈 등록 로직이 맞는지 확인해주세요!