### PR TITLE
[BE] Issue Assignee API

### DIFF
--- a/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
@@ -5,8 +5,11 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.codesquad.issuetracker.exception.ApplicationException;
+import kr.codesquad.issuetracker.exception.ErrorCode;
 import kr.codesquad.issuetracker.infrastructure.persistence.IssueRepository;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
+import kr.codesquad.issuetracker.presentation.request.AssigneeRequest;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -18,5 +21,15 @@ public class IssueService {
 	@Transactional(readOnly = true)
 	public List<IssueSimpleMapper> findAll() {
 		return issueRepository.findAll();
+	}
+
+	@Transactional
+	public void updateAssignees(AssigneeRequest assigneeRequest) {
+		if (!issueRepository.existsById(assigneeRequest.getIssueId())) {
+			throw new ApplicationException(ErrorCode.ISSUE_NOT_FOUND);
+		}
+
+		issueRepository.deleteAssignees(assigneeRequest.getRemoveIssueAssignees());
+		issueRepository.saveAssignees(assigneeRequest.getAddIssueAssignees());
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/application/UserAccountService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/UserAccountService.java
@@ -1,0 +1,28 @@
+package kr.codesquad.issuetracker.application;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.codesquad.issuetracker.infrastructure.persistence.UserAccountRepository;
+import kr.codesquad.issuetracker.presentation.response.UserProfileResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class UserAccountService {
+
+	private final UserAccountRepository userAccountRepository;
+
+	@Transactional(readOnly = true)
+	public List<UserProfileResponse> findAll() {
+		return userAccountRepository.findAll()
+			.stream()
+			.map(userAccount -> new UserProfileResponse(
+				userAccount.getId(), userAccount.getLoginId(), userAccount.getProfileUrl()
+			))
+			.collect(Collectors.toList());
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/domain/IssueAssignee.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/domain/IssueAssignee.java
@@ -8,4 +8,9 @@ public class IssueAssignee {
 	private Integer id;
 	private Integer issueId;
 	private Integer userAccountId;
+
+	public IssueAssignee(Integer issueId, Integer userAccountId) {
+		this.issueId = issueId;
+		this.userAccountId = userAccountId;
+	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/domain/UserAccount.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/domain/UserAccount.java
@@ -1,7 +1,10 @@
 package kr.codesquad.issuetracker.domain;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class UserAccount {
 
@@ -25,5 +28,9 @@ public class UserAccount {
 
 	public boolean isSamePassword(String password) {
 		return this.password.equals(password);
+	}
+
+	public static UserAccount createUserProfile(Integer id, String loginId, String profileUrl) {
+		return new UserAccount(id, loginId, null, profileUrl, false);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/exception/ErrorCode.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/exception/ErrorCode.java
@@ -14,7 +14,10 @@ public enum ErrorCode {
 	// JWT
 	EMPTY_JWT(401, "헤더에 토큰값이 존재하지 않거나 유효하지 않습니다."),
 	INVALID_JWT(401, "유효한 토큰이 아닙니다."),
-	EXPIRED_JWT(401, "만료된 토큰입니다");
+	EXPIRED_JWT(401, "만료된 토큰입니다"),
+
+	// ISSUE
+	ISSUE_NOT_FOUND(404, "존재하지 않는 이슈입니다.");
 
 	private final int statusCode;
 	private final String message;

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueRepository.java
@@ -2,13 +2,16 @@ package kr.codesquad.issuetracker.infrastructure.persistence;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import javax.sql.DataSource;
 
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
 import org.springframework.stereotype.Repository;
 
+import kr.codesquad.issuetracker.domain.IssueAssignee;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
 
 @Repository
@@ -18,6 +21,24 @@ public class IssueRepository {
 
 	public IssueRepository(DataSource dataSource) {
 		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+	}
+
+	public boolean existsById(Integer issueId) {
+		String sql = "SELECT EXISTS (SELECT 1 FROM issue WHERE id = :issueId)";
+
+		return Boolean.TRUE.equals(jdbcTemplate.queryForObject(sql, Map.of("issueId", issueId), Boolean.class));
+	}
+
+	public void saveAssignees(List<IssueAssignee> issueAssignees) {
+		String sql = "INSERT INTO issue_assignee (issue_id, user_account_id) VALUES (:issueId, :userAccountId)";
+
+		jdbcTemplate.batchUpdate(sql, SqlParameterSourceUtils.createBatch(issueAssignees));
+	}
+
+	public void deleteAssignees(List<IssueAssignee> issueAssignees) {
+		String sql = "DELETE FROM issue_assignee WHERE issue_id = :issueId AND user_account_id = :userAccountId";
+
+		jdbcTemplate.batchUpdate(sql, SqlParameterSourceUtils.createBatch(issueAssignees));
 	}
 
 	public List<IssueSimpleMapper> findAll() {

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/UserAccountRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/UserAccountRepository.java
@@ -1,5 +1,6 @@
 package kr.codesquad.issuetracker.infrastructure.persistence;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -42,5 +43,13 @@ public class UserAccountRepository {
 			Map.of("loginId", loginId), (rs, rowNum) -> new UserAccount(rs.getInt("id"),
 				rs.getString("login_id"),
 				rs.getString("password")))));
+	}
+
+	public List<UserAccount> findAll() {
+		String sql = "SELECT id, login_id, profile_url FROM user_account WHERE is_deleted = FALSE";
+
+		return jdbcTemplate.query(sql, (rs, rowNum) -> UserAccount.createUserProfile(rs.getInt("id"),
+			rs.getString("login_id"),
+			rs.getString("profile_url")));
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/IssueController.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/IssueController.java
@@ -4,11 +4,15 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import kr.codesquad.issuetracker.application.IssueService;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
+import kr.codesquad.issuetracker.presentation.request.AssigneeRequest;
 import lombok.RequiredArgsConstructor;
 
 @RequestMapping("/api/issues")
@@ -21,5 +25,11 @@ public class IssueController {
 	@GetMapping
 	public ResponseEntity<List<IssueSimpleMapper>> findAll() {
 		return ResponseEntity.ok(issueService.findAll());
+	}
+
+	@PostMapping("/{issueId}/assignees")
+	public void updateAssignees(@PathVariable Integer issueId, @RequestBody AssigneeRequest assigneeRequest) {
+		assigneeRequest.setIssueId(issueId);
+		issueService.updateAssignees(assigneeRequest);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/UserAccountController.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/UserAccountController.java
@@ -1,0 +1,25 @@
+package kr.codesquad.issuetracker.presentation;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.codesquad.issuetracker.application.UserAccountService;
+import kr.codesquad.issuetracker.presentation.response.UserProfileResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@RestController
+public class UserAccountController {
+
+	private final UserAccountService userAccountService;
+
+	@GetMapping
+	public ResponseEntity<List<UserProfileResponse>> findAll() {
+		return ResponseEntity.ok(userAccountService.findAll());
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/AssigneeRequest.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/AssigneeRequest.java
@@ -1,0 +1,43 @@
+package kr.codesquad.issuetracker.presentation.request;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import kr.codesquad.issuetracker.domain.IssueAssignee;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssigneeRequest {
+
+	private Integer issueId;
+	private List<Integer> addUserAccountsId;
+	private List<Integer> removeUserAccountsId;
+
+	public void setIssueId(Integer issueId) {
+		this.issueId = issueId;
+	}
+
+	public List<IssueAssignee> getAddIssueAssignees() {
+		return toIssueAssignees(addUserAccountsId);
+	}
+
+	public List<IssueAssignee> getRemoveIssueAssignees() {
+		return toIssueAssignees(removeUserAccountsId);
+	}
+
+	private List<IssueAssignee> toIssueAssignees(List<Integer> userAccountsId) {
+		if (Objects.isNull(userAccountsId)) {
+			return Collections.emptyList();
+		}
+
+		return userAccountsId.stream()
+			.map(userAccountId -> new IssueAssignee(issueId, userAccountId))
+			.collect(Collectors.toList());
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/UserProfileResponse.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/UserProfileResponse.java
@@ -1,0 +1,13 @@
+package kr.codesquad.issuetracker.presentation.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UserProfileResponse {
+
+	private Integer userAccountId;
+	private String username;
+	private String profileUrl;
+}

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
@@ -3,17 +3,20 @@ package kr.codesquad.issuetracker.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.List;
+import java.util.Comparator;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import kr.codesquad.issuetracker.ApplicationTest;
 import kr.codesquad.issuetracker.acceptance.DatabaseInitializer;
+import kr.codesquad.issuetracker.exception.ApplicationException;
+import kr.codesquad.issuetracker.exception.ErrorCode;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
+import kr.codesquad.issuetracker.presentation.request.AssigneeRequest;
 
 @ApplicationTest
 class IssueServiceTest {
@@ -28,25 +31,44 @@ class IssueServiceTest {
 		databaseInitializer.initTables();
 	}
 
-	@DisplayName("전체 이슈 목록을 조회할 수 있다.")
+	@DisplayName("전체 이슈 목록을 조회시")
+	@Nested
+	class IssueListTest {
+		@DisplayName("최근에 생성된 순서대로 조회가 된다.")
+		@Test
+		public void sortedIssueNumbers() {
+			var issueNumbers = issueService.findAll().stream()
+				.mapToInt(IssueSimpleMapper::getIssueNumber)
+				.toArray();
+
+			assertThat(issueNumbers).isSortedAccordingTo(Comparator.reverseOrder());
+		}
+
+		@DisplayName("이슈별 담당자, 레이블의 중복이 제거가 된다.")
+		@Test
+		public void matchIssueLabelAndAssigneeCount() {
+			var issueSimpleMappers = issueService.findAll();
+			var firstIssue = issueSimpleMappers.get(0);
+			var lastIssue = issueSimpleMappers.get(2);
+
+			assertAll(
+				() -> assertThat(issueSimpleMappers.size()).isEqualTo(3),
+				() -> assertThat(firstIssue.getLabelSimpleEntities().size()).isEqualTo(0),
+				() -> assertThat(firstIssue.getAssigneeSimpleEntities().size()).isEqualTo(2),
+				() -> assertThat(lastIssue.getLabelSimpleEntities().size()).isEqualTo(3),
+				() -> assertThat(lastIssue.getAssigneeSimpleEntities().size()).isEqualTo(3)
+			);
+		}
+	}
+
+	@DisplayName("존재하지 않는 이슈의 담당자를 수정하면 ISSUE_NOT_FOUND 예외가 발생한다.")
 	@Test
-	public void findAllIssue() {
-		//given
+	public void failedToUpdateAssignee_IfNoExistsIssue() {
+		var assigneeRequest = new AssigneeRequest();
+		assigneeRequest.setIssueId(-1);
 
-		//when
-		List<IssueSimpleMapper> issueSimpleMappers = issueService.findAll();
-		IssueSimpleMapper firstIssue = issueSimpleMappers.get(0);
-		IssueSimpleMapper lastIssue = issueSimpleMappers.get(2);
-
-		//then
-		assertAll(
-			() -> assertThat(issueSimpleMappers.size()).isEqualTo(3),
-			() -> assertThat(firstIssue.getIssueNumber()).isEqualTo(3),
-			() -> assertThat(firstIssue.getLabelSimpleEntities().size()).isEqualTo(0),
-			() -> assertThat(firstIssue.getAssigneeSimpleEntities().size()).isEqualTo(2),
-			() -> assertThat(lastIssue.getIssueNumber()).isEqualTo(1),
-			() -> assertThat(lastIssue.getLabelSimpleEntities().size()).isEqualTo(3),
-			() -> assertThat(lastIssue.getAssigneeSimpleEntities().size()).isEqualTo(3)
-		);
+		assertThatThrownBy(() -> issueService.updateAssignees(assigneeRequest))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ISSUE_NOT_FOUND);
 	}
 }


### PR DESCRIPTION
## Issues
- #43 

## What is this PR? 👓
- 이슈 담당자 목록 조회, 변경 API

## Key changes 🔑
- 특정 이슈의 Assignees을 선택하기 위해 User 목록 조회
- 특정 이슈의 Assignees 추가, 삭제
- 이슈 목록 조회 테스트 수정

## To reviewers 👋
- 기존의 api/assignees는 담당자 리스트를 불러오는 것 같아서 api/users로 변경했습니니다.
- userAccount의 생성자 파라미터에서 password, profileUrl 자리가 겹쳐서 팩토리 메서드를 추가했습니다.
