### PR TITLE
[BE] 이슈 상세 페이지 조회

### DIFF
--- a/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
@@ -18,6 +18,7 @@ import kr.codesquad.issuetracker.infrastructure.persistence.IssueRepository;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
 import kr.codesquad.issuetracker.presentation.request.AssigneeRequest;
 import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
+import kr.codesquad.issuetracker.presentation.response.IssueDetailResponse;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -49,6 +50,14 @@ public class IssueService {
 		return ids.stream()
 			.map(mapper)
 			.collect(Collectors.toList());
+	}
+
+	@Transactional(readOnly = true)
+	public IssueDetailResponse getIssueDetails(Integer issueId) {
+		if (!issueRepository.existsById(issueId)) {
+			throw new ApplicationException(ErrorCode.ISSUE_NOT_FOUND);
+		}
+		return issueRepository.findIssueDetailResponseById(issueId);
 	}
 
 	@Transactional(readOnly = true)

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueRepository.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
+import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Repository;
 
 import kr.codesquad.issuetracker.domain.Issue;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
+import kr.codesquad.issuetracker.presentation.response.IssueDetailResponse;
 
 @Repository
 public class IssueRepository {
@@ -21,12 +23,15 @@ public class IssueRepository {
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 	private final SimpleJdbcInsert jdbcInsert;
 
-	public IssueRepository(DataSource dataSource) {
+	private final MilestoneRepository milestoneRepository;
+
+	public IssueRepository(DataSource dataSource, MilestoneRepository milestoneRepository) {
 		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
 		this.jdbcInsert = new SimpleJdbcInsert(dataSource)
 			.withTableName("issue")
 			.usingGeneratedKeyColumns("id")
 			.usingColumns("title", "is_open", "content", "user_account_id", "milestone_id");
+		this.milestoneRepository = milestoneRepository;
 	}
 
 	public List<IssueSimpleMapper> findAll() {
@@ -66,8 +71,61 @@ public class IssueRepository {
 	}
 
 	public boolean existsById(Integer issueId) {
-		String sql = "SELECT EXISTS (SELECT 1 FROM issue WHERE id = : issueId";
+		String sql = "SELECT EXISTS (SELECT 1 FROM issue WHERE id = :issueId)";
 
 		return Boolean.TRUE.equals(jdbcTemplate.queryForObject(sql, Map.of("issueId", issueId), Boolean.class));
+	}
+
+	public IssueDetailResponse findIssueDetailResponseById(Integer issueId) {
+		List<IssueDetailResponse.Assignee> assignees = findAssigneeById(issueId);
+		List<IssueDetailResponse.LabelInfo> labels = findLabelInfoById(issueId);
+		IssueDetailResponse.MilestoneInfo milestone = milestoneRepository.findMilestoneInfoByIssueId(issueId);
+
+		String sql = "SELECT i.id, i.title, i.is_open, i.created_at, i.content, ua.login_id, ua.profile_url " +
+			"FROM issue i " +
+			"JOIN user_account ua ON i.user_account_id = ua.id AND ua.is_deleted = FALSE " +
+			"WHERE i.id = :issueId";
+
+		return DataAccessUtils.singleResult(
+			jdbcTemplate.query(sql, Map.of("issueId", issueId), (rs, rowNum) -> new IssueDetailResponse(
+				rs.getInt("id"),
+				rs.getString("title"),
+				rs.getBoolean("is_open"),
+				rs.getTimestamp("created_at").toLocalDateTime(),
+				rs.getString("content"),
+				new IssueDetailResponse.Author(rs.getString("login_id"), rs.getString("profile_url")),
+				assignees,
+				labels,
+				milestone
+			)));
+	}
+
+	private List<IssueDetailResponse.Assignee> findAssigneeById(Integer issueId) {
+		String sql = "SELECT ia.user_account_id, ua.login_id, ua.profile_url " +
+			"FROM issue i " +
+			"JOIN issue_assignee ia ON i.id = ia.issue_id " +
+			"JOIN user_account ua ON ia.user_account_id = ua.id AND ua.is_deleted = FALSE " +
+			"WHERE i.id = :issueId";
+
+		return jdbcTemplate.query(sql, Map.of("issueId", issueId), (rs, rowNum) -> new IssueDetailResponse.Assignee(
+			rs.getInt("user_account_id"),
+			rs.getString("login_id"),
+			rs.getString("profile_url")
+		));
+	}
+
+	private List<IssueDetailResponse.LabelInfo> findLabelInfoById(Integer issueId) {
+		String sql = "SELECT l.id, l.name, l.font_color, l.background_color " +
+			"FROM issue i " +
+			"JOIN issue_label il ON i.id = il.issue_id " +
+			"JOIN label l ON il.label_id = l.id AND l.is_deleted = FALSE " +
+			"WHERE i.id = :issueId";
+
+		return jdbcTemplate.query(sql, Map.of("issueId", issueId), (rs, rowNum) -> new IssueDetailResponse.LabelInfo(
+			rs.getInt("id"),
+			rs.getString("name"),
+			rs.getString("font_color"),
+			rs.getString("background_color")
+		));
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/MilestoneRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/MilestoneRepository.java
@@ -1,0 +1,34 @@
+package kr.codesquad.issuetracker.infrastructure.persistence;
+
+import java.util.Map;
+
+import org.springframework.dao.support.DataAccessUtils;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import kr.codesquad.issuetracker.presentation.response.IssueDetailResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class MilestoneRepository {
+
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+
+	public IssueDetailResponse.MilestoneInfo findMilestoneInfoByIssueId(Integer issueId) {
+		String sql =
+			"SELECT m.id, m.name, SUM(i.is_open = TRUE) as open_count, SUM(i.is_open = FALSE) as closed_count " +
+				"FROM milestone m " +
+				"JOIN issue i ON m.id = i.milestone_id AND m.is_deleted = FALSE " +
+				"WHERE i.id = :issueId " +
+				"GROUP BY m.id";
+
+		return DataAccessUtils.singleResult(
+			jdbcTemplate.query(sql, Map.of("issueId", issueId), (rs, rowNum) -> new IssueDetailResponse.MilestoneInfo(
+				rs.getInt("id"),
+				rs.getString("name"),
+				rs.getInt("open_count"),
+				rs.getInt("closed_count")
+			)));
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/mapper/IssueSimpleMapper.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/mapper/IssueSimpleMapper.java
@@ -21,10 +21,10 @@ public class IssueSimpleMapper {
 
 	private Integer issueNumber;
 	private boolean isOpen;
-	private List<LabelSimpleMapper> labelSimpleEntities;
+	private List<LabelSimpleMapper> labels;
 	private String title;
 	private String milestone;
-	private List<AssigneeSimpleMapper> assigneeSimpleEntities;
+	private List<AssigneeSimpleMapper> assignees;
 	private LocalDateTime createdAt;
 
 	@AllArgsConstructor
@@ -44,11 +44,11 @@ public class IssueSimpleMapper {
 	@NoArgsConstructor
 	@Getter
 	public static class AssigneeSimpleMapper {
-		private String loginId;
+		private String username;
 		private String profileUrl;
 
 		public boolean hasValue() {
-			return StringUtils.hasText(loginId);
+			return StringUtils.hasText(username);
 		}
 	}
 

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/IssueController.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/IssueController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +18,7 @@ import kr.codesquad.issuetracker.application.IssueService;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
 import kr.codesquad.issuetracker.presentation.auth.AuthPrincipal;
 import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
+import kr.codesquad.issuetracker.presentation.response.IssueDetailResponse;
 import lombok.RequiredArgsConstructor;
 
 @RequestMapping("/api/issues")
@@ -38,5 +40,11 @@ public class IssueController {
 		return ResponseEntity.status(HttpStatus.FOUND)
 			.header(HttpHeaders.LOCATION, "/api/issues/" + issueId)
 			.build();
+	}
+
+	@GetMapping("/{issueId}")
+	public ResponseEntity<IssueDetailResponse> getIssueDetails(@PathVariable Integer issueId) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(issueService.getIssueDetails(issueId));
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/IssueDetailResponse.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/IssueDetailResponse.java
@@ -1,0 +1,80 @@
+package kr.codesquad.issuetracker.presentation.response;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class IssueDetailResponse {
+
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+	private Integer issueId;
+	private String title;
+	private Boolean isOpen;
+	private String createdAt;
+	private String content;
+	private Author author;
+	private List<Assignee> assignees;
+	private List<LabelInfo> labels;
+	private MilestoneInfo milestone;
+
+	public IssueDetailResponse(Integer issueId, String title, Boolean isOpen, LocalDateTime createdAt, String content,
+		Author author, List<Assignee> assignees, List<LabelInfo> labels, MilestoneInfo milestone) {
+		this.issueId = issueId;
+		this.title = title;
+		this.isOpen = isOpen;
+		this.createdAt = formatter.format(createdAt);
+		this.content = content;
+		this.author = author;
+		this.assignees = assignees;
+		this.labels = labels;
+		this.milestone = milestone;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Author {
+
+		private String username;
+		private String profileUrl;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Assignee {
+
+		private Integer userAccountId;
+		private String username;
+		private String profileUrl;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class LabelInfo {
+
+		private Integer labelId;
+		private String labelName;
+		private String fontColor;
+		private String backgroundColor;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class MilestoneInfo {
+
+		private Integer milestoneId;
+		private String milestoneName;
+		private Integer openIssueCount;
+		private Integer closedIssueCount;
+	}
+}

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
@@ -14,12 +14,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import kr.codesquad.issuetracker.ApplicationTest;
 import kr.codesquad.issuetracker.acceptance.DatabaseInitializer;
-import kr.codesquad.issuetracker.fixture.FixtureFactory;
 import kr.codesquad.issuetracker.exception.ApplicationException;
 import kr.codesquad.issuetracker.exception.ErrorCode;
+import kr.codesquad.issuetracker.fixture.FixtureFactory;
 import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMapper;
-import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
 import kr.codesquad.issuetracker.presentation.request.AssigneeRequest;
+import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
+import kr.codesquad.issuetracker.presentation.response.IssueDetailResponse;
 
 @ApplicationTest
 class IssueServiceTest {
@@ -48,7 +49,7 @@ class IssueServiceTest {
 		// then
 		List<IssueSimpleMapper> result = issueService.findAll();
 		assertAll(
-			() -> assertThat(result.get(0).getIssueNumber()).isEqualTo(4),
+			() -> assertThat(result.get(0).getIssueNumber()).isNotNull(),
 			() -> assertThat(result.get(0).isOpen()).isTrue(),
 			() -> assertThat(result.get(0).getTitle()).isEqualTo("프로젝트 세팅하기")
 		);
@@ -81,6 +82,40 @@ class IssueServiceTest {
 				() -> assertThat(lastIssue.getLabelSimpleEntities().size()).isEqualTo(3),
 				() -> assertThat(lastIssue.getAssigneeSimpleEntities().size()).isEqualTo(3)
 			);
+		}
+	}
+
+	@DisplayName("이슈 상세페이지를 조회할 때")
+	@Nested
+	class IssueDetailTest {
+
+		@DisplayName("이슈 상세페이지 조회에 성공한다.")
+		@Test
+		void getIssueDetail() {
+			// given
+
+			// when
+			IssueDetailResponse result = issueService.getIssueDetails(1);
+
+			// then
+			assertAll(
+				() -> assertThat(result.getIssueId()).isNotNull(),
+				() -> assertThat(result.getAuthor().getUsername()).isNotNull(),
+				() -> assertThat(result.getAuthor().getProfileUrl()).isNotNull(),
+				() -> assertThat(result.getAssignees()).isNotNull(),
+				() -> assertThat(result.getLabels()).isNotNull()
+			);
+		}
+
+		@DisplayName("존재하지 않는 이슈 아이디가 주어져 예외를 던진다.")
+		@Test
+		void givenNotExistsIssueId_thenThrowsException() {
+			// given
+
+			// when & then
+			assertThatThrownBy(() -> issueService.getIssueDetails(0))
+				.isInstanceOf(ApplicationException.class)
+				.extracting("errorCode").isEqualTo(ErrorCode.ISSUE_NOT_FOUND);
 		}
 	}
 

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
@@ -77,10 +77,10 @@ class IssueServiceTest {
 
 			assertAll(
 				() -> assertThat(issueSimpleMappers.size()).isEqualTo(3),
-				() -> assertThat(firstIssue.getLabelSimpleEntities().size()).isEqualTo(0),
-				() -> assertThat(firstIssue.getAssigneeSimpleEntities().size()).isEqualTo(2),
-				() -> assertThat(lastIssue.getLabelSimpleEntities().size()).isEqualTo(3),
-				() -> assertThat(lastIssue.getAssigneeSimpleEntities().size()).isEqualTo(3)
+				() -> assertThat(firstIssue.getLabels().size()).isEqualTo(0),
+				() -> assertThat(firstIssue.getAssignees().size()).isEqualTo(2),
+				() -> assertThat(lastIssue.getLabels().size()).isEqualTo(3),
+				() -> assertThat(lastIssue.getAssignees().size()).isEqualTo(3)
 			);
 		}
 	}

--- a/backend/src/test/java/kr/codesquad/issuetracker/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/fixture/FixtureFactory.java
@@ -1,10 +1,12 @@
 package kr.codesquad.issuetracker.fixture;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
 import kr.codesquad.issuetracker.presentation.request.LoginRequest;
 import kr.codesquad.issuetracker.presentation.request.SignupRequest;
+import kr.codesquad.issuetracker.presentation.response.IssueDetailResponse;
 
 public class FixtureFactory {
 
@@ -25,5 +27,16 @@ public class FixtureFactory {
 			labelIds,
 			1
 		);
+	}
+
+	public static IssueDetailResponse createIssueDetailResponse() {
+		return new IssueDetailResponse(1, "이슈 제목", true, LocalDateTime.now(), "이슈 내용",
+			new IssueDetailResponse.Author("작성자", "url"),
+			List.of(new IssueDetailResponse.Assignee(2, "담당자", "url"),
+				new IssueDetailResponse.Assignee(3, "담당자2", "url")),
+
+			List.of(new IssueDetailResponse.LabelInfo(1, "feat", "#fff", "#ddd")),
+
+			new IssueDetailResponse.MilestoneInfo(1, "BE Sprint #1", 3, 5));
 	}
 }

--- a/backend/src/test/java/kr/codesquad/issuetracker/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/presentation/AuthControllerTest.java
@@ -7,25 +7,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kr.codesquad.issuetracker.application.AuthService;
 import kr.codesquad.issuetracker.fixture.FixtureFactory;
 import kr.codesquad.issuetracker.presentation.response.TokenResponse;
 
 @WebMvcTest(controllers = AuthController.class)
-class AuthControllerTest {
-
-	@Autowired
-	private MockMvc mockMvc;
-	@Autowired
-	private ObjectMapper objectMapper;
+class AuthControllerTest extends ControllerTest {
 
 	@MockBean
 	AuthService authService;


### PR DESCRIPTION
## Issues
- #56 

## What is this PR? 👓
이슈 상세페이지 조회 기능에 대한 PR입니다.

![image](https://github.com/issue-tracker-08/issue-tracker-max/assets/66981851/ad8b95ca-693c-4336-b782-5ce21151d2bf)


## Key changes 🔑
- 이슈 상세 페이지 조회
  - 이슈 제목, 내용, 작성자 조회
  - 이슈의 담당자 목록 조회
  - 이슈의 라벨 목록 조회
  - 이슈의 마일스톤 조회
- 이슈 전체 목록조회에서 API에 맞게 필드명 수정
- 테스트코드 작성

## To reviewers 👋
현재 `IssueRepository`의 `findIssueDetailResponseById`메서드에서 결과에 필요한 모든 쿼리를 날리고 있는데 이를 어떻게 분리하면 좋을 지 모르겠습니다ㅠ
