### PR TITLE
[FE] IssueDetailHeader 컴포넌트 구현

### DIFF
--- a/fe/src/api/index.ts
+++ b/fe/src/api/index.ts
@@ -36,6 +36,20 @@ export const getIssueDetails = async (issueId: number) => {
   );
 };
 
+export const putIssueTitle = async (
+  issueId: number,
+  body: { title: string }
+) => {
+  return await fetcherWithBearer.put(`/issues/${issueId}/title`, body);
+};
+
+export const putIssueIsOpen = async (
+  issueId: number,
+  body: { isOpen: boolean }
+) => {
+  return await fetcherWithBearer.put(`/issues/${issueId}/isOpen`, body);
+};
+
 export const getIssueSidebar = async (issueId: number) => {
   return await fetcherWithBearer.get<IssueSidebar>(
     `/issues/${issueId}/sidebar`

--- a/fe/src/components/Issues/IssueDetail/IssueDetailHeader.tsx
+++ b/fe/src/components/Issues/IssueDetail/IssueDetailHeader.tsx
@@ -7,7 +7,7 @@ import TextInput from "@components/common/TextInput";
 import { IssueDetails } from "@customTypes/index";
 import { convertPastTimestamp } from "@utils/time";
 import { putIssueIsOpen, putIssueTitle } from "api";
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useState } from "react";
 import { styled } from "styled-components";
 
 export default function IssueDetailHeader({
@@ -21,9 +21,6 @@ export default function IssueDetailHeader({
   updateIssueIsOpen: () => void;
   numComments: number;
 }) {
-  const [isEditTitle, setIsEditTitle] = useState(false);
-  const [newTitle, setNewTitle] = useState("");
-
   const { issueId, author, title, createdAt, isOpen } = issueDetails || {
     issueId: 0,
     author: { username: "", profileURl: "" },
@@ -32,9 +29,14 @@ export default function IssueDetailHeader({
     isOpen: true,
   };
 
-  useEffect(() => {
+  const [isEditTitle, setIsEditTitle] = useState(false);
+  const [newTitle, setNewTitle] = useState(title);
+  const [prevTitle, setPrevTitle] = useState(title);
+
+  if (title !== prevTitle) {
+    setPrevTitle(title);
     setNewTitle(title);
-  }, [title]);
+  }
 
   const onNewTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setNewTitle(e.target.value);

--- a/fe/src/components/Issues/IssueDetail/IssueDetailHeader.tsx
+++ b/fe/src/components/Issues/IssueDetail/IssueDetailHeader.tsx
@@ -16,7 +16,7 @@ export default function IssueDetailHeader({
   updateIssueIsOpen,
   numComments,
 }: {
-  issueDetails: IssueDetails;
+  issueDetails: IssueDetails | null;
   updateIssueTitle: (newTitle: string) => void;
   updateIssueIsOpen: () => void;
   numComments: number;
@@ -24,7 +24,13 @@ export default function IssueDetailHeader({
   const [isEditTitle, setIsEditTitle] = useState(false);
   const [newTitle, setNewTitle] = useState("");
 
-  const { issueId, author, title, createdAt, isOpen } = issueDetails;
+  const { issueId, author, title, createdAt, isOpen } = issueDetails || {
+    issueId: 0,
+    author: { username: "", profileURl: "" },
+    title: "",
+    createdAt: new Date().toISOString(),
+    isOpen: true,
+  };
 
   useEffect(() => {
     setNewTitle(title);

--- a/fe/src/components/Issues/IssueDetail/IssueDetailHeader.tsx
+++ b/fe/src/components/Issues/IssueDetail/IssueDetailHeader.tsx
@@ -1,0 +1,208 @@
+import alertIcon from "@assets/icon/alertCircle.svg";
+import archiveIcon from "@assets/icon/archive.svg";
+import editIcon from "@assets/icon/edit.svg";
+import xIcon from "@assets/icon/xSquare.svg";
+import Button from "@components/common/Button";
+import TextInput from "@components/common/TextInput";
+import { IssueDetails } from "@customTypes/index";
+import { convertPastTimestamp } from "@utils/time";
+import { putIssueIsOpen, putIssueTitle } from "api";
+import { FormEvent, useEffect, useState } from "react";
+import { styled } from "styled-components";
+
+export default function IssueDetailHeader({
+  issueDetails,
+  updateIssueTitle,
+  updateIssueIsOpen,
+  numComments,
+}: {
+  issueDetails: IssueDetails;
+  updateIssueTitle: (newTitle: string) => void;
+  updateIssueIsOpen: () => void;
+  numComments: number;
+}) {
+  const [isEditTitle, setIsEditTitle] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+
+  const { issueId, author, title, createdAt, isOpen } = issueDetails;
+
+  useEffect(() => {
+    setNewTitle(title);
+  }, [title]);
+
+  const onNewTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNewTitle(e.target.value);
+  };
+
+  const onNewTitleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    try {
+      const res = await putIssueTitle(issueId, {
+        title: newTitle,
+      });
+
+      if (res.statusText === "OK") {
+        updateIssueTitle(newTitle);
+        setIsEditTitle(false);
+      }
+    } catch (error) {
+      // TODO
+      console.error(error);
+    }
+  };
+
+  const onUpdateIsOpen = async () => {
+    try {
+      const res = await putIssueIsOpen(issueId, {
+        isOpen: !isOpen,
+      });
+
+      if (res.statusText === "OK") {
+        updateIssueIsOpen();
+      }
+    } catch (error) {
+      // TODO
+      console.error(error);
+    }
+  };
+
+  return (
+    <Header>
+      <TitleAndButtons>
+        {isEditTitle ? (
+          <form action="" onSubmit={onNewTitleSubmit}>
+            <TextInput
+              name="issueTitle"
+              variant="short"
+              placeholder="제목"
+              value={newTitle}
+              onChange={onNewTitleChange}
+            />
+
+            <ButtonsWrapper>
+              <Button
+                variant="outline"
+                size="S"
+                onClick={() => setIsEditTitle(false)}>
+                <img src={xIcon} alt="편집 취소" />
+                <span>편집 취소</span>
+              </Button>
+              <Button variant="container" size="S" disabled={title === ""}>
+                <img src={editIcon} alt="편집 완료" />
+                <span>편집 완료</span>
+              </Button>
+            </ButtonsWrapper>
+          </form>
+        ) : (
+          <>
+            <TitleWrapper>
+              <h1>{title}</h1>
+              <span>#{issueId}</span>
+            </TitleWrapper>
+
+            <ButtonsWrapper>
+              <Button
+                variant="outline"
+                size="S"
+                onClick={() => setIsEditTitle(true)}>
+                <img src={editIcon} alt="제목 편집" />
+                <span>제목 편집</span>
+              </Button>
+              <Button variant="outline" size="S" onClick={onUpdateIsOpen}>
+                <img
+                  src={isOpen ? archiveIcon : alertIcon}
+                  alt={`이슈 ${isOpen ? "닫기" : "열기"}`}
+                />
+                <span>이슈 {`${isOpen ? "닫기" : "열기"}`}</span>
+              </Button>
+            </ButtonsWrapper>
+          </>
+        )}
+      </TitleAndButtons>
+
+      <IssueInfo>
+        <IssueStateTag $isOpen={isOpen}>
+          <img src={isOpen ? alertIcon : archiveIcon} alt="열린 이슈" />
+          <span>{`${isOpen ? "열린" : "닫힌"}`} 이슈</span>
+        </IssueStateTag>
+
+        <p>
+          이 이슈는 {convertPastTimestamp(createdAt)}에 {author?.username}에
+          의해 열렸습니다 ∙ 코멘트 {numComments}개
+        </p>
+      </IssueInfo>
+    </Header>
+  );
+}
+
+const Header = styled.header`
+  width: 100%;
+  margin-bottom: 24px;
+`;
+
+const TitleAndButtons = styled.div`
+  width: 100%;
+  margin-bottom: 16px;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+
+  form {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+  }
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  gap: 8px;
+
+  h1 {
+    font: ${({ theme: { font } }) => font.displayBold32};
+    color: ${({ theme: { neutral } }) => neutral.text.strong};
+  }
+
+  span {
+    font: ${({ theme: { font } }) => font.displayBold32};
+    color: ${({ theme: { neutral } }) => neutral.text.weak};
+  }
+`;
+
+const ButtonsWrapper = styled.div`
+  display: flex;
+  gap: 16px;
+`;
+
+const IssueInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  p {
+    font: ${({ theme: { font } }) => font.displayMD16};
+    color: ${({ theme: { neutral } }) => neutral.text.weak};
+  }
+`;
+
+const IssueStateTag = styled.div<{ $isOpen: boolean }>`
+  height: 32px;
+  padding-inline: 16px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background-color: ${({ theme: { palette, neutral }, $isOpen }) =>
+    $isOpen ? palette.blue : neutral.text.weak};
+  border-radius: ${({ theme: { radius } }) => radius.l};
+
+  img {
+    filter: ${({ theme: { filter } }) => filter.brandTextDefault};
+  }
+
+  span {
+    font: ${({ theme: { font } }) => font.displayMD12};
+    color: ${({ theme: { brand } }) => brand.text.default};
+  }
+`;

--- a/fe/src/components/common/Label.tsx
+++ b/fe/src/components/common/Label.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 export const Label = styled.label`
+  width: 64px;
   display: flex;
   align-items: center;
   font: ${({ theme: { font } }) => font.displayMD12};

--- a/fe/src/components/common/TextInput.tsx
+++ b/fe/src/components/common/TextInput.tsx
@@ -25,7 +25,7 @@ export default function TextInput({
           <Label htmlFor={name}>{props.placeholder}</Label>
         )}
         {!isTallType && <Label htmlFor={name}>{props.placeholder}</Label>}
-        <Input id={name} {...props} />
+        <Input id={name} value={value} {...props} />
       </InputContainer>
       {hasError && helpText && (
         <HelpTextArea $hasError={hasError}>{helpText}</HelpTextArea>
@@ -40,6 +40,7 @@ const INPUT_HEIGHT = {
 };
 
 const StyledTextInput = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 4px;

--- a/fe/src/mocks/data.ts
+++ b/fe/src/mocks/data.ts
@@ -116,7 +116,7 @@ export const issueList = [
 ];
 
 export const issueDetails = {
-  issueId: 3,
+  issueId: 1,
   title: "이슈 제목",
   isOpen: true,
   createdAt: "2023-07-31 11:33:03",

--- a/fe/src/mocks/handlers.ts
+++ b/fe/src/mocks/handlers.ts
@@ -37,6 +37,7 @@ export const handlers = [
     const { username, password } = await req.json<AuthRequestBody>();
     const isExist = loginInfo[username];
     const isCorrectPassword = loginInfo[username] === password;
+    console.log("login attempt!");
 
     if (!isExist) {
       return res(
@@ -85,6 +86,8 @@ export const handlers = [
   rest.get("/api/issues/:issueId/sidebar", async (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(issueSidebar));
   }),
+
+  // TODO: issue edit api
 
   rest.get("/api/labels", async (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(labelList));

--- a/fe/src/mocks/handlers.ts
+++ b/fe/src/mocks/handlers.ts
@@ -37,7 +37,6 @@ export const handlers = [
     const { username, password } = await req.json<AuthRequestBody>();
     const isExist = loginInfo[username];
     const isCorrectPassword = loginInfo[username] === password;
-    console.log("login attempt!");
 
     if (!isExist) {
       return res(
@@ -83,11 +82,17 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(issueDetails));
   }),
 
+  rest.put("/api/issues/:issueId/title", async (_, res, ctx) => {
+    return res(ctx.status(200));
+  }),
+
+  rest.put("/api/issues/:issueId/isOpen", async (_, res, ctx) => {
+    return res(ctx.status(200));
+  }),
+
   rest.get("/api/issues/:issueId/sidebar", async (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(issueSidebar));
   }),
-
-  // TODO: issue edit api
 
   rest.get("/api/labels", async (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(labelList));

--- a/fe/src/pages/MainPage/IssueDetailPage.tsx
+++ b/fe/src/pages/MainPage/IssueDetailPage.tsx
@@ -34,16 +34,14 @@ export default function IssueDetailPage() {
 
   return (
     <>
-      {issueDetails && (
-        <IssueDetailHeader
-          {...{
-            issueDetails,
-            updateIssueTitle,
-            updateIssueIsOpen,
-            numComments: 0,
-          }}
-        />
-      )}
+      <IssueDetailHeader
+        {...{
+          issueDetails,
+          updateIssueTitle,
+          updateIssueIsOpen,
+          numComments: 0,
+        }}
+      />
 
       {issueSidebar && (
         <IssueDetailBody {...{ issueNumber, ...issueSidebar }} />

--- a/fe/src/pages/MainPage/IssueDetailPage.tsx
+++ b/fe/src/pages/MainPage/IssueDetailPage.tsx
@@ -1,8 +1,8 @@
-// import IssueDetailHeader from "@components/Issues/IssueDetail/IssueDetailHeader";
 import IssueDetailBody from "@components/Issues/IssueDetail/IssueDetailBody";
-import { IssueSidebar } from "@customTypes/index";
+import IssueDetailHeader from "@components/Issues/IssueDetail/IssueDetailHeader";
+import { IssueDetails, IssueSidebar } from "@customTypes/index";
 import useFetch from "@hooks/useFetch";
-import { getIssueSidebar } from "api";
+import { getIssueDetails, getIssueSidebar } from "api";
 import { useCallback } from "react";
 import { useParams } from "react-router-dom";
 
@@ -10,15 +10,41 @@ export default function IssueDetailPage() {
   const { issueId } = useParams();
   const issueNumber = parseInt(issueId!);
 
+  const { data: issueDetails, setData: setIssueDetails } =
+    useFetch<IssueDetails>(
+      useCallback(() => getIssueDetails(issueNumber), [issueNumber])
+    );
   const { data: issueSidebar } = useFetch<IssueSidebar>(
     useCallback(() => getIssueSidebar(issueNumber), [issueNumber])
   );
 
   // TODO: comments useFetch
-  // TODO: fetch comments
+
+  const updateIssueTitle = (newTitle: string) => {
+    setIssueDetails((prev) => {
+      return prev ? { ...prev, title: newTitle } : prev;
+    });
+  };
+
+  const updateIssueIsOpen = () => {
+    setIssueDetails((prev) => {
+      return prev ? { ...prev, isOpen: !prev.isOpen } : prev;
+    });
+  };
 
   return (
     <>
+      {issueDetails && (
+        <IssueDetailHeader
+          {...{
+            issueDetails,
+            updateIssueTitle,
+            updateIssueIsOpen,
+            numComments: 0,
+          }}
+        />
+      )}
+
       {issueSidebar && (
         <IssueDetailBody {...{ issueNumber, ...issueSidebar }} />
       )}


### PR DESCRIPTION
## Issues
- #79 

## What is this PR? 👓
- IssueDetailHeader 컴포넌트 구현.

## Key changes 🔑
- IssueDetailHeader에서 issue 제목, 열림/닫힘 수정 기능 추가.
- `TextInput` 컴포넌트에서 input으로 value 전달.
- Null check
  - 기존: `issueDetails && <IssueDetailHeader />`
  - 수정: `IssueDetailHeader` 내부에서 `issueDetails`가 null 일시에 초기 값 설정.

## To reviewers 👋
- `api/index.ts`에 `putIssueTitle` 및 `putIssueIsOpen` 함수의 `body`의 type이 너무 작아서 `api/type.ts`에 선언하지 않고 함수 인자에 바로 표시했습니다.