### PR TITLE
[BE] 프론트와의 협의사항 반영

### DIFF
--- a/backend/src/main/java/kr/codesquad/issuetracker/application/CommentService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/CommentService.java
@@ -1,5 +1,6 @@
 package kr.codesquad.issuetracker.application;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -9,6 +10,7 @@ import kr.codesquad.issuetracker.domain.Comment;
 import kr.codesquad.issuetracker.exception.ApplicationException;
 import kr.codesquad.issuetracker.exception.ErrorCode;
 import kr.codesquad.issuetracker.infrastructure.persistence.CommentRepository;
+import kr.codesquad.issuetracker.presentation.response.CommentRegisterResponse;
 import kr.codesquad.issuetracker.presentation.response.CommentsResponse;
 import kr.codesquad.issuetracker.presentation.response.Slice;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +22,10 @@ public class CommentService {
 	private final CommentRepository commentRepository;
 
 	@Transactional
-	public void register(Integer userId, String content, Integer issueId) {
+	public CommentRegisterResponse register(Integer userId, String content, Integer issueId) {
 		Comment comment = new Comment(content, userId, issueId);
-		commentRepository.save(comment);
+		int commentId = commentRepository.save(comment);
+		return new CommentRegisterResponse(commentId, content, LocalDateTime.now());
 	}
 
 	@Transactional

--- a/backend/src/main/java/kr/codesquad/issuetracker/application/LabelService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/LabelService.java
@@ -21,7 +21,11 @@ public class LabelService {
 	public List<LabelResponse> findAll() {
 		return labelRepository.findAll().stream()
 			.map(label -> new LabelResponse(
-				label.getId(), label.getName(), label.getFontColor(), label.getBackgroundColor()
+				label.getId(),
+				label.getName(),
+				label.getDescription(),
+				label.getFontColor(),
+				label.getBackgroundColor()
 			))
 			.collect(Collectors.toList());
 	}

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/CommentRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/CommentRepository.java
@@ -29,8 +29,8 @@ public class CommentRepository {
 			.usingGeneratedKeyColumns("id");
 	}
 
-	public void save(Comment comment) {
-		jdbcInsert.execute(new BeanPropertySqlParameterSource(comment));
+	public int save(Comment comment) {
+		return jdbcInsert.executeAndReturnKey(new BeanPropertySqlParameterSource(comment)).intValue();
 	}
 
 	public Optional<Comment> findById(Integer commentId) {

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/IssueRepository.java
@@ -79,7 +79,10 @@ public class IssueRepository {
 	public Optional<IssueDetailResponse> findIssueDetailResponseById(Integer issueId) {
 		String sql =
 			"SELECT issue.id, issue.title, issue.is_open, issue.created_at, issue.content, " +
-				"user_account.login_id, user_account.profile_url " +
+				"user_account.login_id, user_account.profile_url, ("
+				+ "SELECT COUNT(1) "
+				+ "FROM comment "
+				+ "WHERE comment.issue_id = :issueId AND comment.is_deleted = FALSE) AS comment_count " +
 				"FROM issue " +
 				"JOIN user_account ON issue.user_account_id = user_account.id AND user_account.is_deleted = FALSE " +
 				"WHERE issue.id = :issueId";
@@ -91,7 +94,8 @@ public class IssueRepository {
 				rs.getBoolean("is_open"),
 				rs.getTimestamp("created_at").toLocalDateTime(),
 				rs.getString("content"),
-				new IssueDetailResponse.Author(rs.getString("login_id"), rs.getString("profile_url"))
+				new IssueDetailResponse.Author(rs.getString("login_id"), rs.getString("profile_url")),
+				rs.getInt("comment_count")
 			))));
 	}
 

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/CommentController.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/CommentController.java
@@ -17,6 +17,7 @@ import kr.codesquad.issuetracker.application.CommentService;
 import kr.codesquad.issuetracker.presentation.auth.AuthPrincipal;
 import kr.codesquad.issuetracker.presentation.auth.Principal;
 import kr.codesquad.issuetracker.presentation.request.CommentRequest;
+import kr.codesquad.issuetracker.presentation.response.CommentRegisterResponse;
 import kr.codesquad.issuetracker.presentation.response.CommentsResponse;
 import kr.codesquad.issuetracker.presentation.response.Slice;
 import lombok.RequiredArgsConstructor;
@@ -29,10 +30,10 @@ public class CommentController {
 	private final CommentService commentService;
 
 	@PostMapping
-	public ResponseEntity<Void> register(@AuthPrincipal Principal principal,
+	public ResponseEntity<CommentRegisterResponse> register(@AuthPrincipal Principal principal,
 		@Valid @RequestBody CommentRequest request, @PathVariable Integer issueId) {
-		commentService.register(principal.getUserId(), request.getContent(), issueId);
-		return ResponseEntity.status(HttpStatus.CREATED).build();
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(commentService.register(principal.getUserId(), request.getContent(), issueId));
 	}
 
 	@PutMapping("/{commentId}")

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/CommentRegisterResponse.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/CommentRegisterResponse.java
@@ -1,0 +1,20 @@
+package kr.codesquad.issuetracker.presentation.response;
+
+import java.time.LocalDateTime;
+
+import kr.codesquad.issuetracker.presentation.support.DateTimeFormatterUtil;
+import lombok.Getter;
+
+@Getter
+public class CommentRegisterResponse {
+
+	private final Integer commentId;
+	private final String content;
+	private final String createdAt;
+
+	public CommentRegisterResponse(Integer commentId, String content, LocalDateTime createdAt) {
+		this.commentId = commentId;
+		this.content = content;
+		this.createdAt = DateTimeFormatterUtil.toString(createdAt);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/CommentsResponse.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/CommentsResponse.java
@@ -2,16 +2,23 @@ package kr.codesquad.issuetracker.presentation.response;
 
 import java.time.LocalDateTime;
 
-import lombok.AllArgsConstructor;
+import kr.codesquad.issuetracker.presentation.support.DateTimeFormatterUtil;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class CommentsResponse {
 
 	private Integer id;
 	private String username;
 	private String profileUrl;
 	private String content;
-	private LocalDateTime createdAt;
+	private String createdAt;
+
+	public CommentsResponse(Integer id, String username, String profileUrl, String content, LocalDateTime createdAt) {
+		this.id = id;
+		this.username = username;
+		this.profileUrl = profileUrl;
+		this.content = content;
+		this.createdAt = DateTimeFormatterUtil.toString(createdAt);
+	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/IssueDetailResponse.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/IssueDetailResponse.java
@@ -19,15 +19,18 @@ public class IssueDetailResponse {
 	private String createdAt;
 	private String content;
 	private Author author;
+	private Integer commentCount;
 
 	public IssueDetailResponse(Integer issueId, String title, Boolean isOpen, LocalDateTime createdAt, String content,
-		Author author) {
+		Author author,
+		Integer commentCount) {
 		this.issueId = issueId;
 		this.title = title;
 		this.isOpen = isOpen;
 		this.createdAt = formatter.format(createdAt);
 		this.content = content;
 		this.author = author;
+		this.commentCount = commentCount;
 	}
 
 	@Getter

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/IssueDetailResponse.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/IssueDetailResponse.java
@@ -1,8 +1,8 @@
 package kr.codesquad.issuetracker.presentation.response;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
+import kr.codesquad.issuetracker.presentation.support.DateTimeFormatterUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,8 +10,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class IssueDetailResponse {
-
-	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
 	private Integer issueId;
 	private String title;
@@ -27,7 +25,7 @@ public class IssueDetailResponse {
 		this.issueId = issueId;
 		this.title = title;
 		this.isOpen = isOpen;
-		this.createdAt = formatter.format(createdAt);
+		this.createdAt = DateTimeFormatterUtil.toString(createdAt);
 		this.content = content;
 		this.author = author;
 		this.commentCount = commentCount;

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/LabelResponse.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/LabelResponse.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public class LabelResponse {
 
 	private Integer labelId;
-	private String labelName;
+	private String name;
+	private String description;
 	private String fontColor;
 	private String backgroundColor;
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/support/DateTimeFormatterUtil.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/support/DateTimeFormatterUtil.java
@@ -1,0 +1,16 @@
+package kr.codesquad.issuetracker.presentation.support;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public final class DateTimeFormatterUtil {
+
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+	private DateTimeFormatterUtil() {
+	}
+
+	public static String toString(LocalDateTime localDateTime) {
+		return formatter.format(localDateTime);
+	}
+}

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
@@ -105,7 +105,8 @@ class IssueServiceTest {
 			assertAll(
 				() -> assertThat(result.getIssueId()).isNotNull(),
 				() -> assertThat(result.getAuthor().getUsername()).isNotNull(),
-				() -> assertThat(result.getAuthor().getProfileUrl()).isNotNull()
+				() -> assertThat(result.getAuthor().getProfileUrl()).isNotNull(),
+				() -> assertThat(result.getCommentCount()).isNotNull()
 			);
 		}
 

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/LabelServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/LabelServiceTest.java
@@ -4,21 +4,16 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.Comparator;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import kr.codesquad.issuetracker.ApplicationTest;
-import kr.codesquad.issuetracker.acceptance.DatabaseInitializer;
 import kr.codesquad.issuetracker.presentation.response.LabelResponse;
 
 @ApplicationTest
 class LabelServiceTest {
-
-	@Autowired
-	private DatabaseInitializer databaseInitializer;
 
 	@Autowired
 	private LabelService labelService;
@@ -26,15 +21,16 @@ class LabelServiceTest {
 	@MockBean
 	private S3Service s3Service;
 
-	@BeforeEach
-	void setUp() {
-		databaseInitializer.initTables();
-	}
-
 	@DisplayName("label 목록 조회시 이름순으로 정렬이 된다.")
 	@Test
 	void findLabelsSortedNameAscending() {
+		// given
+		labelService.register("feat", "기능 개발", "#FFF", "#EDE");
+		labelService.register("setting", "기능 개발", "#FFF", "#EDE");
+		labelService.register("backend", "기능 개발", "#FFF", "#EDE");
+
+		// when & then
 		assertThat(labelService.findAll())
-			.isSortedAccordingTo(Comparator.comparing(LabelResponse::getLabelName));
+			.isSortedAccordingTo(Comparator.comparing(LabelResponse::getName));
 	}
 }

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/unit/CommentServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/unit/CommentServiceTest.java
@@ -31,7 +31,7 @@ class CommentServiceTest {
 	@Test
 	void register() {
 		// given
-		willDoNothing().given(commentRepository).save(any(Comment.class));
+		given(commentRepository.save(any(Comment.class))).willReturn(1);
 
 		// when & then
 		assertThatCode(() -> commentService.register(1, "안녕하세요", 2))

--- a/backend/src/test/java/kr/codesquad/issuetracker/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/fixture/FixtureFactory.java
@@ -32,7 +32,7 @@ public class FixtureFactory {
 
 	public static IssueDetailResponse createIssueDetailResponse() {
 		return new IssueDetailResponse(1, "이슈 제목", true, LocalDateTime.now(), "이슈 내용",
-			new IssueDetailResponse.Author("작성자", "url"));
+			new IssueDetailResponse.Author("작성자", "url"), 10);
 	}
 
 	public static MilestoneCommonRequest createMilestoneCommonRequest(String title) {


### PR DESCRIPTION
## Issues
- #117 

## What is this PR? 👓
프론트와의 협의사항들을 반영한 PR입니다.

## Key changes 🔑
- 이슈 상세 페이지에서 해당 이슈의 전체 댓글 수 반환
- 댓글 작성 성공시 response body 생성 후 응답
- 라벨 전체 목록 조회시 `description` response 필드에 추가

## To reviewers 👋
- 협의점들이 정상 반영됐는지 확인해주세요!
- 댓글 작성 성공시 `createdAt` 필드를 반환해야합니다. 처음 응답하는 시간이 그렇게 중요하지 않다고 생각해서 DB에서 조회 쿼리를 한 번 더 날리는 것보다 애플리케이션에서 `LocalDateTime.now()`를 호출해 응답했습니다.
