### PR TITLE
[BE] 마일스톤 관련 기능 수정 및 열기, 닫기 기능 추가

### DIFF
--- a/backend/src/main/java/kr/codesquad/issuetracker/application/CommentService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/CommentService.java
@@ -45,7 +45,7 @@ public class CommentService {
 		if (comments.isEmpty()) {
 			return new Slice<>(List.of(), false, 0);
 		}
-		cursor = comments.get(comments.size() - 1).getId();
+		cursor = comments.get(comments.size() - 1).getCommentId();
 
 		return new Slice<>(comments, cursor);
 	}

--- a/backend/src/main/java/kr/codesquad/issuetracker/application/CommentService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/CommentService.java
@@ -1,6 +1,7 @@
 package kr.codesquad.issuetracker.application;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -25,7 +26,7 @@ public class CommentService {
 	public CommentRegisterResponse register(Integer userId, String content, Integer issueId) {
 		Comment comment = new Comment(content, userId, issueId);
 		int commentId = commentRepository.save(comment);
-		return new CommentRegisterResponse(commentId, content, LocalDateTime.now());
+		return new CommentRegisterResponse(commentId, content, LocalDateTime.now(ZoneId.of("Asia/Seoul")));
 	}
 
 	@Transactional

--- a/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
@@ -109,9 +109,9 @@ public class IssueService {
 			throw new ApplicationException(ErrorCode.ISSUE_NOT_FOUND);
 		}
 
-		assigneeRepository.saveAll(toEntityList(request.getAddUserAccountsId(),
+		assigneeRepository.saveAll(toEntityList(request.getAddUserAccountId(),
 			id -> new IssueAssignee(issueId, id)));
-		assigneeRepository.deleteAll(toEntityList(request.getRemoveUserAccountsId(),
+		assigneeRepository.deleteAll(toEntityList(request.getRemoveUserAccountId(),
 			id -> new IssueAssignee(issueId, id)));
 	}
 

--- a/backend/src/main/java/kr/codesquad/issuetracker/application/MilestoneService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/MilestoneService.java
@@ -20,8 +20,8 @@ public class MilestoneService {
 	private final MilestoneRepository milestoneRepository;
 
 	@Transactional(readOnly = true)
-	public List<MilestoneResponse> findAll() {
-		return milestoneRepository.findAll();
+	public List<MilestoneResponse> findAll(boolean isOpen) {
+		return milestoneRepository.findAll(isOpen);
 	}
 
 	@Transactional

--- a/backend/src/main/java/kr/codesquad/issuetracker/application/MilestoneService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/MilestoneService.java
@@ -1,6 +1,6 @@
 package kr.codesquad.issuetracker.application;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -25,13 +25,13 @@ public class MilestoneService {
 	}
 
 	@Transactional
-	public void register(String name, String description, LocalDateTime dueDate) {
+	public void register(String name, String description, LocalDate dueDate) {
 		Milestone milestone = new Milestone(name, description, dueDate);
 		milestoneRepository.save(milestone);
 	}
 
 	@Transactional
-	public void modify(Integer milestoneId, String milestoneName, String description, LocalDateTime dueDate) {
+	public void modify(Integer milestoneId, String milestoneName, String description, LocalDate dueDate) {
 		Milestone milestone = milestoneRepository.findById(milestoneId)
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MILESTONE_NOT_FOUND));
 

--- a/backend/src/main/java/kr/codesquad/issuetracker/application/MilestoneService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/MilestoneService.java
@@ -43,5 +43,9 @@ public class MilestoneService {
 	public void remove(Integer milestoneId) {
 		milestoneRepository.deleteById(milestoneId);
 	}
-}
 
+	@Transactional
+	public void changeOpenState(Integer milestoneId, boolean isOpen) {
+		milestoneRepository.updateOpenState(milestoneId, isOpen);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/domain/Milestone.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/domain/Milestone.java
@@ -1,7 +1,7 @@
 package kr.codesquad.issuetracker.domain;
 
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import lombok.Getter;
 
@@ -11,7 +11,7 @@ public class Milestone {
 	private Integer id;
 	private String name;
 	private String description;
-	private LocalDateTime dueDate;
+	private LocalDate dueDate;
 	private Boolean isOpen;
 	private Boolean isDeleted;
 
@@ -20,17 +20,17 @@ public class Milestone {
 		this.name = name;
 		this.description = description;
 		if (dueDate != null) {
-			this.dueDate = dueDate.toLocalDateTime();
+			this.dueDate = dueDate.toLocalDateTime().toLocalDate();
 		}
 	}
 
-	public Milestone(String name, String description, LocalDateTime dueDate) {
+	public Milestone(String name, String description, LocalDate dueDate) {
 		this.name = name;
 		this.description = description;
 		this.dueDate = dueDate;
 	}
 
-	public void modify(String name, String description, LocalDateTime dueDate) {
+	public void modify(String name, String description, LocalDate dueDate) {
 		this.name = name;
 		this.description = description;
 		this.dueDate = dueDate;

--- a/backend/src/main/java/kr/codesquad/issuetracker/domain/Milestone.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/domain/Milestone.java
@@ -12,6 +12,7 @@ public class Milestone {
 	private String name;
 	private String description;
 	private LocalDateTime dueDate;
+	private Boolean isOpen;
 	private Boolean isDeleted;
 
 	public Milestone(Integer id, String name, String description, Timestamp dueDate) {

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/config/WebConfig.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/config/WebConfig.java
@@ -3,11 +3,13 @@ package kr.codesquad.issuetracker.infrastructure.config;
 import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import kr.codesquad.issuetracker.presentation.auth.AuthPrincipalArgumentResolver;
+import kr.codesquad.issuetracker.presentation.converter.OpenStateConverter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class WebConfig implements WebMvcConfigurer {
 
 	private final AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
+	private final OpenStateConverter openStateConverter;
 
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -26,5 +29,10 @@ public class WebConfig implements WebMvcConfigurer {
 		registry.addMapping("/api/**")
 			.allowedOrigins("http://issue-tracker-8.s3-website.ap-northeast-2.amazonaws.com", "http://localhost:5173")
 			.allowedMethods("HEAD", "OPTIONS", "GET", "POST", "PUT", "DELETE", "PATCH");
+	}
+
+	@Override
+	public void addFormatters(FormatterRegistry registry) {
+		registry.addConverter(openStateConverter);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/MilestoneRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/MilestoneRepository.java
@@ -93,13 +93,13 @@ public class MilestoneRepository {
 		jdbcTemplate.update(sql, params);
 	}
 
-	public void updateOpenState(Integer milestoneId, boolean milestone) {
+	public void updateOpenState(Integer milestoneId, boolean isOpen) {
 		String sql = "UPDATE milestone "
 			+ "SET milestone.is_open = :openState "
 			+ "WHERE id = :milestoneId";
 
 		MapSqlParameterSource params = new MapSqlParameterSource()
-			.addValue("openState", milestone)
+			.addValue("openState", isOpen)
 			.addValue("milestoneId", milestoneId);
 		jdbcTemplate.update(sql, params);
 	}

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/MilestoneRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/MilestoneRepository.java
@@ -90,4 +90,15 @@ public class MilestoneRepository {
 			.addValue("milestoneId", milestoneId);
 		jdbcTemplate.update(sql, params);
 	}
+
+	public void updateOpenState(Integer milestoneId, boolean milestone) {
+		String sql = "UPDATE milestone "
+			+ "SET milestone.is_open = :openState "
+			+ "WHERE id = :milestoneId";
+
+		MapSqlParameterSource params = new MapSqlParameterSource()
+			.addValue("openState", milestone)
+			.addValue("milestoneId", milestoneId);
+		jdbcTemplate.update(sql, params);
+	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/MilestoneRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/MilestoneRepository.java
@@ -30,19 +30,21 @@ public class MilestoneRepository {
 	}
 
 	public List<MilestoneResponse> findAll() {
-		String sql = "SELECT milestone.id, milestone.name, milestone.description, milestone.due_date, "
-			+ "IFNULL(SUM(issue.is_open = TRUE), 0) as open_count, "
-			+ "IFNULL(SUM(issue.is_open = FALSE), 0) as closed_count "
-			+ "FROM milestone "
-			+ "LEFT JOIN issue ON milestone.id = issue.milestone_id AND issue.is_deleted = FALSE "
-			+ "WHERE milestone.is_deleted = FALSE "
-			+ "GROUP BY milestone.id";
+		String sql =
+			"SELECT milestone.id, milestone.name, milestone.description, milestone.due_date, milestone.is_open, "
+				+ "IFNULL(SUM(issue.is_open = TRUE), 0) as open_count, "
+				+ "IFNULL(SUM(issue.is_open = FALSE), 0) as closed_count "
+				+ "FROM milestone "
+				+ "LEFT JOIN issue ON milestone.id = issue.milestone_id AND issue.is_deleted = FALSE "
+				+ "WHERE milestone.is_deleted = FALSE "
+				+ "GROUP BY milestone.id";
 
 		return jdbcTemplate.query(sql, (rs, rowNum) -> new MilestoneResponse(
 			rs.getInt("id"),
 			rs.getString("name"),
 			rs.getString("description"),
 			rs.getTimestamp("due_date"),
+			rs.getBoolean("is_open"),
 			rs.getInt("open_count"),
 			rs.getInt("closed_count")
 		));

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/MilestoneRepository.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/MilestoneRepository.java
@@ -29,17 +29,19 @@ public class MilestoneRepository {
 			.usingGeneratedKeyColumns("id");
 	}
 
-	public List<MilestoneResponse> findAll() {
+	public List<MilestoneResponse> findAll(boolean isOpen) {
 		String sql =
 			"SELECT milestone.id, milestone.name, milestone.description, milestone.due_date, milestone.is_open, "
 				+ "IFNULL(SUM(issue.is_open = TRUE), 0) as open_count, "
 				+ "IFNULL(SUM(issue.is_open = FALSE), 0) as closed_count "
 				+ "FROM milestone "
 				+ "LEFT JOIN issue ON milestone.id = issue.milestone_id AND issue.is_deleted = FALSE "
-				+ "WHERE milestone.is_deleted = FALSE "
+				+ "WHERE milestone.is_open = :isOpen AND milestone.is_deleted = FALSE "
 				+ "GROUP BY milestone.id";
+		MapSqlParameterSource params = new MapSqlParameterSource()
+			.addValue("isOpen", isOpen);
 
-		return jdbcTemplate.query(sql, (rs, rowNum) -> new MilestoneResponse(
+		return jdbcTemplate.query(sql, params, (rs, rowNum) -> new MilestoneResponse(
 			rs.getInt("id"),
 			rs.getString("name"),
 			rs.getString("description"),

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/MilestoneController.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/MilestoneController.java
@@ -13,9 +13,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import kr.codesquad.issuetracker.application.MilestoneService;
+import kr.codesquad.issuetracker.presentation.converter.OpenState;
 import kr.codesquad.issuetracker.presentation.request.MilestoneCommonRequest;
 import kr.codesquad.issuetracker.presentation.response.MilestoneResponse;
 import lombok.RequiredArgsConstructor;
@@ -50,5 +52,12 @@ public class MilestoneController {
 	public ResponseEntity<Void> remove(@PathVariable Integer milestoneId) {
 		milestoneService.remove(milestoneId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@PutMapping(path = "/{milestoneId}", params = "state")
+	public ResponseEntity<Void> changeOpenState(@PathVariable Integer milestoneId,
+		@RequestParam("state") OpenState state) {
+		milestoneService.changeOpenState(milestoneId, state.isOpen());
+		return ResponseEntity.ok().build();
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/MilestoneController.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/MilestoneController.java
@@ -30,8 +30,9 @@ public class MilestoneController {
 	private final MilestoneService milestoneService;
 
 	@GetMapping
-	public ResponseEntity<List<MilestoneResponse>> findAll() {
-		return ResponseEntity.ok(milestoneService.findAll());
+	public ResponseEntity<List<MilestoneResponse>> findAll(
+		@RequestParam(value = "state", required = false, defaultValue = "open") OpenState state) {
+		return ResponseEntity.ok(milestoneService.findAll(state.isOpen()));
 	}
 
 	@PostMapping

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/converter/OpenState.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/converter/OpenState.java
@@ -1,0 +1,27 @@
+package kr.codesquad.issuetracker.presentation.converter;
+
+import kr.codesquad.issuetracker.exception.ApplicationException;
+import kr.codesquad.issuetracker.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public enum OpenState {
+
+	OPEN(Boolean.TRUE), CLOSED(Boolean.FALSE);
+
+	private final boolean isOpen;
+
+	OpenState(boolean isOpen) {
+		this.isOpen = isOpen;
+	}
+
+	public static OpenState of(String openState) {
+		if (openState.equals("open")) {
+			return OPEN;
+		}
+		if (openState.equals("closed")) {
+			return CLOSED;
+		}
+		throw new ApplicationException(ErrorCode.INVALID_INPUT);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/converter/OpenStateConverter.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/converter/OpenStateConverter.java
@@ -1,0 +1,13 @@
+package kr.codesquad.issuetracker.presentation.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OpenStateConverter implements Converter<String, OpenState> {
+
+	@Override
+	public OpenState convert(String openState) {
+		return OpenState.of(openState);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/AssigneeRequest.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/AssigneeRequest.java
@@ -13,16 +13,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AssigneeRequest {
 
-	private List<Integer> addUserAccountsId;
-	private List<Integer> removeUserAccountsId;
+	private List<Integer> addUserAccountId;
+	private List<Integer> removeUserAccountId;
 
-	public List<Integer> getAddUserAccountsId() {
-		return Optional.ofNullable(addUserAccountsId)
+	public List<Integer> getAddUserAccountId() {
+		return Optional.ofNullable(addUserAccountId)
 			.orElseGet(Collections::emptyList);
 	}
 
-	public List<Integer> getRemoveUserAccountsId() {
-		return Optional.ofNullable(removeUserAccountsId)
+	public List<Integer> getRemoveUserAccountId() {
+		return Optional.ofNullable(removeUserAccountId)
 			.orElseGet(Collections::emptyList);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/MilestoneCommonRequest.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/request/MilestoneCommonRequest.java
@@ -1,7 +1,6 @@
 package kr.codesquad.issuetracker.presentation.request;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDate;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
@@ -17,12 +16,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MilestoneCommonRequest {
 
-	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
 	@NotBlank(message = "마일스톤의 이름은 빈 값이 들어올 수 없습니다.")
 	@Size(max = 45, message = "마일스톤의 이름은 45자를 넘을 수 없습니다.")
 	private String milestoneName;
 	private String description;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-	private LocalDateTime dueDate;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+	private LocalDate dueDate;
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/CommentsResponse.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/CommentsResponse.java
@@ -8,14 +8,15 @@ import lombok.Getter;
 @Getter
 public class CommentsResponse {
 
-	private Integer id;
+	private Integer commentId;
 	private String username;
 	private String profileUrl;
 	private String content;
 	private String createdAt;
 
-	public CommentsResponse(Integer id, String username, String profileUrl, String content, LocalDateTime createdAt) {
-		this.id = id;
+	public CommentsResponse(Integer commentId, String username, String profileUrl, String content,
+		LocalDateTime createdAt) {
+		this.commentId = commentId;
 		this.username = username;
 		this.profileUrl = profileUrl;
 		this.content = content;

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/MilestoneResponse.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/MilestoneResponse.java
@@ -18,23 +18,25 @@ public class MilestoneResponse {
 	private String description;
 	@JsonInclude(value = JsonInclude.Include.NON_NULL)
 	private LocalDateTime dueDate;
+	private Boolean isOpen;
 	private Integer openIssueCount;
 	private Integer closedIssueCount;
 
-	public MilestoneResponse(Integer milestoneId, String milestoneName, String description, Timestamp dueDate,
-		Integer openIssueCount, Integer closedIssueCount) {
+	public MilestoneResponse(Integer milestoneId,
+		String milestoneName,
+		String description,
+		Timestamp dueDate,
+		Boolean isOpen,
+		Integer openIssueCount,
+		Integer closedIssueCount) {
 		this.milestoneId = milestoneId;
 		this.milestoneName = milestoneName;
 		this.description = description;
 		if (dueDate != null) {
 			this.dueDate = dueDate.toLocalDateTime();
 		}
+		this.isOpen = isOpen;
 		this.openIssueCount = openIssueCount;
 		this.closedIssueCount = closedIssueCount;
-	}
-
-	public MilestoneResponse(Integer milestoneId, String milestoneName, Integer openIssueCount,
-		Integer closedIssueCount) {
-		this(milestoneId, milestoneName, null, null, openIssueCount, closedIssueCount);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/MilestoneResponse.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/response/MilestoneResponse.java
@@ -1,7 +1,7 @@
 package kr.codesquad.issuetracker.presentation.response;
 
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -17,7 +17,7 @@ public class MilestoneResponse {
 	@JsonInclude(value = JsonInclude.Include.NON_NULL)
 	private String description;
 	@JsonInclude(value = JsonInclude.Include.NON_NULL)
-	private LocalDateTime dueDate;
+	private LocalDate dueDate;
 	private Boolean isOpen;
 	private Integer openIssueCount;
 	private Integer closedIssueCount;
@@ -33,7 +33,7 @@ public class MilestoneResponse {
 		this.milestoneName = milestoneName;
 		this.description = description;
 		if (dueDate != null) {
-			this.dueDate = dueDate.toLocalDateTime();
+			this.dueDate = dueDate.toLocalDateTime().toLocalDate();
 		}
 		this.isOpen = isOpen;
 		this.openIssueCount = openIssueCount;

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS `issue_tracker`.`milestone`
     `name`        VARCHAR(45)  NOT NULL,
     `description` VARCHAR(256) NULL,
     `due_date`    TIMESTAMP    NULL,
+    `is_open`     TINYINT      NOT NULL DEFAULT 1,
     `is_deleted`  TINYINT      NOT NULL DEFAULT 0,
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;

--- a/backend/src/test/java/kr/codesquad/issuetracker/acceptance/MilestoneAcceptanceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/acceptance/MilestoneAcceptanceTest.java
@@ -25,7 +25,7 @@ public class MilestoneAcceptanceTest extends AcceptanceTest {
 			.body(Map.of(
 				"milestoneName", "BE 1주차 스프린트",
 				"description", "화이팅!",
-				"dueDate", "2023-09-01 00:00:00"));
+				"dueDate", "2023-09-01"));
 
 		// when
 		var response = given

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/LabelServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/LabelServiceTest.java
@@ -44,7 +44,7 @@ class LabelServiceTest {
 		List<LabelResponse> result = labelService.findAll();
 
 		assertAll(
-			() -> assertThat(result.get(0).getLabelName()).isEqualTo("after"),
+			() -> assertThat(result.get(0).getName()).isEqualTo("after"),
 			() -> assertThat(result.get(0).getFontColor()).isEqualTo("black"),
 			() -> assertThat(result.get(0).getBackgroundColor()).isEqualTo("1111"));
 

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/MilestoneServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/MilestoneServiceTest.java
@@ -36,7 +36,7 @@ class MilestoneServiceTest {
 		milestoneService.register("BE 1주차 스프린트", "열심히 하자", dueDate);
 
 		// then
-		List<MilestoneResponse> milestones = milestoneService.findAll();
+		List<MilestoneResponse> milestones = milestoneService.findAll(true);
 		assertAll(
 			() -> assertThat(milestones).hasSize(1),
 			() -> assertThat(milestones.get(0).getMilestoneId()).isEqualTo(1),
@@ -61,7 +61,7 @@ class MilestoneServiceTest {
 			milestoneService.modify(1, "BE 2주차 스프린트", "2주차", dueDate);
 
 			// then
-			List<MilestoneResponse> result = milestoneService.findAll();
+			List<MilestoneResponse> result = milestoneService.findAll(true);
 
 			assertAll(
 				() -> assertThat(result.get(0).getMilestoneName()).isEqualTo("BE 2주차 스프린트"),
@@ -92,6 +92,6 @@ class MilestoneServiceTest {
 		milestoneService.remove(1);
 
 		// then
-		assertThat(milestoneService.findAll()).hasSize(0);
+		assertThat(milestoneService.findAll(true)).hasSize(0);
 	}
 }

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/MilestoneServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/MilestoneServiceTest.java
@@ -3,7 +3,7 @@ package kr.codesquad.issuetracker.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +30,7 @@ class MilestoneServiceTest {
 	@Test
 	void register() {
 		// given
-		LocalDateTime dueDate = LocalDateTime.of(2023, 9, 1, 0, 0, 0);
+		LocalDate dueDate = LocalDate.of(2023, 9, 1);
 
 		// when
 		milestoneService.register("BE 1주차 스프린트", "열심히 하자", dueDate);
@@ -54,7 +54,7 @@ class MilestoneServiceTest {
 		@Test
 		void modify() {
 			// given
-			LocalDateTime dueDate = LocalDateTime.parse("2023-09-01T00:00:00");
+			LocalDate dueDate = LocalDate.of(2023, 9, 1);
 			milestoneService.register("BE 1주차 스프린트", null, null);
 
 			// when

--- a/backend/src/test/java/kr/codesquad/issuetracker/presentation/MilestoneControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/presentation/MilestoneControllerTest.java
@@ -5,7 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Map;
 
 import org.apache.http.HttpHeaders;
@@ -33,7 +33,7 @@ class MilestoneControllerTest extends ControllerTest {
 		@Test
 		void register() throws Exception {
 			// given
-			willDoNothing().given(milestoneService).register(anyString(), anyString(), any(LocalDateTime.class));
+			willDoNothing().given(milestoneService).register(anyString(), anyString(), any(LocalDate.class));
 
 			// when & then
 			mockMvc.perform(
@@ -51,7 +51,7 @@ class MilestoneControllerTest extends ControllerTest {
 		@Test
 		void givenInvalidRegisterInfo_thenResponse400() throws Exception {
 			// given
-			willDoNothing().given(milestoneService).register(anyString(), anyString(), any(LocalDateTime.class));
+			willDoNothing().given(milestoneService).register(anyString(), anyString(), any(LocalDate.class));
 
 			// when & then
 			mockMvc.perform(
@@ -74,7 +74,7 @@ class MilestoneControllerTest extends ControllerTest {
 		void modify() throws Exception {
 			// given
 			willDoNothing().given(milestoneService)
-				.modify(anyInt(), anyString(), anyString(), any(LocalDateTime.class));
+				.modify(anyInt(), anyString(), anyString(), any(LocalDate.class));
 
 			// when & then
 			mockMvc.perform(
@@ -93,7 +93,7 @@ class MilestoneControllerTest extends ControllerTest {
 		void givenInvalidRegisterInfo_thenResponse400() throws Exception {
 			// given
 			willDoNothing().given(milestoneService)
-				.modify(anyInt(), anyString(), anyString(), any(LocalDateTime.class));
+				.modify(anyInt(), anyString(), anyString(), any(LocalDate.class));
 
 			// when & then
 			mockMvc.perform(


### PR DESCRIPTION
## Issues
- #126 

## What is this PR? 👓
- 마일스톤 관련 기능 수정
- 마일스톤 열기 / 닫기 기능 추가

## Key changes 🔑
- 마일스톤 열기/닫기 기능추가
  - PUT /api/milestones/1?state=open
  - PUT /api/milestones/1?state=closed
- 마일스톤 열림/닫힘 기능이 기획서에 있지만 `milestone` 테이블에 `is_open` 컬럼이 존재하지 않아 이를 추가
- 마일스톤 생성/수정시 만료일이 년-월-일 만 받지만 현재 시간까지 받고 있어 이를 수정
- 마일스톤 전체 목록 조회시
  - 쿼리 파라미터로 `?state=open` -> 열린 마일스톤만 조회
  - 쿼리 파라미터로 `?state=closed` -> 닫힌 마일스톤만 조회

\+ 추가
- 댓글목록 조회시 response의 id를 commentId로 수정

## To reviewers 👋
- 마일스톤 열기/닫기 기능을 쿼리 파라미터로 받았습니다! 다른 의견있으면 말해주세용
- 마일스톤 스키마를 수정해서 DB에도 반영해주세요!
