### PR TITLE
[BE] fix: 이슈 목록 조회 필터 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - be-w4
       - fe-w4
+  push:
+    branches:
+      - be-w4
+      - fe-w4
 
 env:
   AWS_REGION: ap-northeast-2

--- a/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
@@ -76,7 +76,7 @@ public class IssueService {
 
 	@Transactional(readOnly = true)
 	public Page<IssueSimpleMapper> findAll(String loginId, String searchBar, int page, int size) {
-		int offset = (page - 1) * size; // 7 and 9
+		int offset = (page - 1) * size;
 		int totalCounts = issueMapper.countAll(IssueSearchParser.parse(loginId, searchBar));
 		final IssueSearch issueSearch = IssueSearchParser.parse(loginId, searchBar);
 		List<IssueSimpleMapper> issues = issueMapper.findAll(issueSearch, offset, size);

--- a/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/IssueService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import kr.codesquad.issuetracker.domain.Issue;
 import kr.codesquad.issuetracker.domain.IssueAssignee;
 import kr.codesquad.issuetracker.domain.IssueLabel;
+import kr.codesquad.issuetracker.domain.IssueSearch;
 import kr.codesquad.issuetracker.exception.ApplicationException;
 import kr.codesquad.issuetracker.exception.ErrorCode;
 import kr.codesquad.issuetracker.infrastructure.persistence.IssueAssigneeRepository;
@@ -75,9 +76,10 @@ public class IssueService {
 
 	@Transactional(readOnly = true)
 	public Page<IssueSimpleMapper> findAll(String loginId, String searchBar, int page, int size) {
-		int offset = (page - 1) * size;
+		int offset = (page - 1) * size; // 7 and 9
 		int totalCounts = issueMapper.countAll(IssueSearchParser.parse(loginId, searchBar));
-		List<IssueSimpleMapper> issues = issueMapper.findAll(IssueSearchParser.parse(loginId, searchBar), offset, size);
+		final IssueSearch issueSearch = IssueSearchParser.parse(loginId, searchBar);
+		List<IssueSimpleMapper> issues = issueMapper.findAll(issueSearch, offset, size);
 		return Page.of(issues, totalCounts, page, size);
 	}
 

--- a/backend/src/main/java/kr/codesquad/issuetracker/domain/IssueSearch.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/domain/IssueSearch.java
@@ -27,11 +27,11 @@ public class IssueSearch {
 	@Builder.Default()
 	private List<String> labelNames = new ArrayList<>();
 
-	public void registerIssueStatus(String issueStatus) {
-		if ("open".equals(issueStatus)) {
+	public void registerState(String state) {
+		if ("open".equals(state)) {
 			isOpen = true;
 		}
-		if ("close".equals(issueStatus)) {
+		if ("closed".equals(state)) {
 			isOpen = false;
 		}
 	}

--- a/backend/src/main/java/kr/codesquad/issuetracker/domain/IssueSearchFilter.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/domain/IssueSearchFilter.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum IssueSearchFilter {
 
-	STATUS("is:", IssueSearch::registerIssueStatus),
+	STATE("is:", IssueSearch::registerState),
 	AUTHOR("author:", IssueSearch::registerAuthor),
 	COMMENTER("commenter:", IssueSearch::registerCommenter),
 	ASSIGNEE("assignee:", IssueSearch::addAssignee),

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/mapper/AssigneeSimpleMapper.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/mapper/AssigneeSimpleMapper.java
@@ -1,7 +1,5 @@
 package kr.codesquad.issuetracker.infrastructure.persistence.mapper;
 
-import org.springframework.util.StringUtils;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/mapper/LabelSimpleMapper.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/mapper/LabelSimpleMapper.java
@@ -1,7 +1,5 @@
 package kr.codesquad.issuetracker.infrastructure.persistence.mapper;
 
-import org.springframework.util.StringUtils;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/resources/mapper/IssueMapper.xml
+++ b/backend/src/main/resources/mapper/IssueMapper.xml
@@ -31,34 +31,24 @@
     </resultMap>
 
     <select id="findAll" resultMap="issueResultMap">
-        SELECT DISTINCT issue.id as issue_id,
-        issue.is_open as issue_is_open,
-        issue.title as issue_title,
-        issue.created_at as issue_created_at,
-        milestone.name as milestone_name,
-        author.id as author_id,
-        author.login_id as author_login_id,
-        author.profile_url as author_profile_url,
-        label.id as label_id,
-        label.name as label_name,
-        label.font_color as label_font_color,
-        label.background_color as label_background_color,
-        assignee.id as assignee_id,
-        assignee.login_id as assignee_login_id,
-        assignee.profile_url as assignee_profile_url
-
-        <include refid="filter"></include>
-
-        ORDER BY issue.id DESC
-        LIMIT #{offset}, #{size};
-    </select>
-
-    <select id="countAll" resultType="int">
-        SELECT COUNT(DISTINCT issue.id)
-        <include refid="filter"></include>;
-    </select>
-
-    <sql id="filter">
+    SELECT * FROM (
+        SELECT DISTINCT
+            issue.id as issue_id,
+            issue.is_open as issue_is_open,
+            issue.title as issue_title,
+            issue.created_at as issue_created_at,
+            milestone.name as milestone_name,
+            author.id as author_id,
+            author.login_id as author_login_id,
+            author.profile_url as author_profile_url,
+            label.id as label_id,
+            label.name as label_name,
+            label.font_color as label_font_color,
+            label.background_color as label_background_color,
+            assignee.id as assignee_id,
+            assignee.login_id as assignee_login_id,
+            assignee.profile_url as assignee_profile_url,
+            DENSE_RANK() OVER (ORDER BY issue.id DESC) as row_num
         FROM issue
         LEFT JOIN issue_label ON issue.id = issue_label.issue_id
         LEFT JOIN label ON label.id = issue_label.label_id AND label.is_deleted = false
@@ -66,10 +56,58 @@
         LEFT JOIN user_account assignee ON assignee.id = issue_assignee.user_account_id AND assignee.is_deleted = false
         LEFT JOIN milestone ON issue.milestone_id = milestone.id AND milestone.is_deleted = false
         JOIN user_account author ON author.id = issue.user_account_id AND author.is_deleted = false
-        <if test="issueSearch.author != null">
-            AND author.login_id = #{issueSearch.author}
-        </if>
-        WHERE issue.is_deleted = false
+        <where>
+            <if test="issueSearch.isOpen != null">
+                AND issue.is_open = #{issueSearch.isOpen}
+            </if>
+            <if test="issueSearch.milestoneName != null">
+                AND milestone.name = #{issueSearch.milestoneName}
+            </if>
+            <if test="issueSearch.commenter != null">
+                AND issue.id IN (
+                    SELECT issue_id
+                    FROM user_account
+                    JOIN comment ON user_account.id = comment.user_account_id AND comment.is_deleted = FALSE
+                    WHERE login_id = #{issueSearch.commenter}
+                )
+            </if>
+            <if test="!issueSearch.labelNames.isEmpty()">
+                AND label.name IN
+                <foreach collection="issueSearch.labelNames" item="labelName" open="(" close=")" separator=",">
+                    #{labelName}
+                </foreach>
+            </if>
+            <if test="!issueSearch.assigneeNames.isEmpty()">
+                AND assignee.login_id IN
+                <foreach collection="issueSearch.assigneeNames" item="assigneeName" open="(" close=")" separator=",">
+                    #{assigneeName}
+                </foreach>
+            </if>
+            <if test="issueSearch.hasLabel == false">
+                AND label.id IS NULL
+            </if>
+            <if test="issueSearch.hasMilestone == false">
+                AND milestone.id IS NULL
+            </if>
+            <if test="issueSearch.hasAssignee == false">
+                AND assignee.id IS NULL
+            </if>
+        </where>
+    ) as result
+    WHERE result.row_num BETWEEN #{offset} + 1 AND #{offset} + #{size};
+    </select>
+
+    <select id="countAll" resultType="int">
+        SELECT COUNT(DISTINCT issue.id) FROM issue
+
+        LEFT JOIN issue_label ON issue.id = issue_label.issue_id
+        LEFT JOIN label ON label.id = issue_label.label_id AND label.is_deleted = false
+        LEFT JOIN issue_assignee ON issue.id = issue_assignee.issue_id
+        LEFT JOIN user_account assignee ON assignee.id = issue_assignee.user_account_id AND assignee.is_deleted = false
+        LEFT JOIN milestone ON issue.milestone_id = milestone.id AND milestone.is_deleted = false
+        JOIN user_account author ON author.id = issue.user_account_id AND author.is_deleted = false
+
+        WHERE issue.is_deleted = FALSE
         <if test="issueSearch.isOpen != null">
             AND issue.is_open = #{issueSearch.isOpen}
         </if>
@@ -77,16 +115,11 @@
             AND milestone.name = #{issueSearch.milestoneName}
         </if>
         <if test="issueSearch.commenter != null">
-            AND issue.id IN
-            (
-            SELECT issue_id
-            FROM comment
-            WHERE user_account_id =
-            (
-            SELECT id
-            FROM user_account
-            WHERE login_id = #{issueSearch.commenter}
-            )
+            AND issue.id IN (
+                SELECT issue_id
+                FROM user_account
+                JOIN comment ON user_account.id = comment.user_account_id AND comment.is_deleted = FALSE
+                WHERE login_id = #{issueSearch.commenter}
             )
         </if>
         <if test="!issueSearch.labelNames.isEmpty()">
@@ -110,6 +143,5 @@
         <if test="issueSearch.hasAssignee == false">
             AND assignee.id IS NULL
         </if>
-    </sql>
-
+    </select>
 </mapper>

--- a/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/application/IssueServiceTest.java
@@ -22,6 +22,7 @@ import kr.codesquad.issuetracker.infrastructure.persistence.mapper.IssueSimpleMa
 import kr.codesquad.issuetracker.presentation.request.AssigneeRequest;
 import kr.codesquad.issuetracker.presentation.request.IssueRegisterRequest;
 import kr.codesquad.issuetracker.presentation.response.IssueDetailResponse;
+import kr.codesquad.issuetracker.presentation.response.Page;
 
 @ApplicationTest
 class IssueServiceTest {
@@ -51,11 +52,13 @@ class IssueServiceTest {
 		issueService.register(1, request);
 
 		// then
-		List<IssueSimpleMapper> result = issueService.findAll();
+		Page<IssueSimpleMapper> result = issueService.findAll("bin1234", null, 1, 20);
+		List<IssueSimpleMapper> issues = result.getData();
+
 		assertAll(
-			() -> assertThat(result.get(0).getIssueNumber()).isNotNull(),
-			() -> assertThat(result.get(0).getIsOpen()).isTrue(),
-			() -> assertThat(result.get(0).getTitle()).isEqualTo("프로젝트 세팅하기")
+			() -> assertThat(issues.get(0).getIssueNumber()).isNotNull(),
+			() -> assertThat(issues.get(0).getIsOpen()).isTrue(),
+			() -> assertThat(issues.get(0).getTitle()).isEqualTo("프로젝트 세팅하기")
 		);
 	}
 
@@ -65,7 +68,8 @@ class IssueServiceTest {
 		@DisplayName("최근에 생성된 순서대로 조회가 된다.")
 		@Test
 		void sortedIssueNumbers() {
-			var issueNumbers = issueService.findAll().stream()
+			var issueNumbers = issueService.findAll("bin1234", null, 1, 20).getData()
+				.stream()
 				.mapToInt(IssueSimpleMapper::getIssueNumber)
 				.toArray();
 
@@ -75,12 +79,13 @@ class IssueServiceTest {
 		@DisplayName("이슈별 담당자, 레이블의 중복이 제거가 된다.")
 		@Test
 		void matchIssueLabelAndAssigneeCount() {
-			var issueSimpleMappers = issueService.findAll();
-			var firstIssue = issueSimpleMappers.get(0);
-			var lastIssue = issueSimpleMappers.get(2);
+			var issues = issueService.findAll("bin1234", null, 1, 20)
+				.getData();
+			var firstIssue = issues.get(0);
+			var lastIssue = issues.get(2);
 
 			assertAll(
-				() -> assertThat(issueSimpleMappers.size()).isEqualTo(3),
+				() -> assertThat(issues.size()).isEqualTo(3),
 				() -> assertThat(firstIssue.getLabels().size()).isEqualTo(0),
 				() -> assertThat(firstIssue.getAssignees().size()).isEqualTo(2),
 				() -> assertThat(lastIssue.getLabels().size()).isEqualTo(3),

--- a/backend/src/test/java/kr/codesquad/issuetracker/utils/IssueSearchParserTest.java
+++ b/backend/src/test/java/kr/codesquad/issuetracker/utils/IssueSearchParserTest.java
@@ -47,7 +47,7 @@ class IssueSearchParserTest {
 					.build()
 			),
 			Arguments.of(
-				"is:close commenter:tommy milestone:\"milestone name\" label:label1 label:label2",
+				"is:closed commenter:tommy milestone:\"milestone name\" label:label1 label:label2",
 				IssueSearch.builder()
 					.isOpen(false)
 					.commenter("tommy")


### PR DESCRIPTION


## What is this PR? 👓
- #158

## Key changes 🔑
- 페이징 조회시 결과가 잘려서(이슈 목록 10개가 보여야 하는데 5개가 조회되는) 나오는 문제 발생
- LEFT JOIN으로 결과가 증가해서 LIMIT로 자를 수 없음
- DENSE_RANK()를 사용해서 해결
- 이슈 상태 (status: open, close)를 (state: open, closed)로 변경

## To reviewers 👋
- 쿼리가 크다보니 테스트 코드 작성이나 직접 테스트 해보기가 어려운 것 같습니다..!
- 더 효율적인 방법이 생각나시면 말씀해주세요!