### PR TITLE
[FE] GitHub OAuth 로그인/회원가입

### DIFF
--- a/fe/src/api/index.ts
+++ b/fe/src/api/index.ts
@@ -26,8 +26,8 @@ export const postLogin = async (username: string, password: string) => {
   return await fetcher.post("/auth/login", { loginId: username, password });
 };
 
-export const getOAuthLogin = async () => {
-  return await fetcher.get("/auth/login/oauth");
+export const getGitHubLogin = async (code: string) => {
+  return await fetcher.get(`/auth/login/oauth/github?code=${code}`);
 };
 
 export const postOAuthUsername = async (body: {

--- a/fe/src/api/index.ts
+++ b/fe/src/api/index.ts
@@ -26,6 +26,17 @@ export const postLogin = async (username: string, password: string) => {
   return await fetcher.post("/auth/login", { loginId: username, password });
 };
 
+export const getOAuthLogin = async () => {
+  return await fetcher.get("/auth/login/oauth");
+};
+
+export const postOAuthUsername = async (body: {
+  username: string;
+  email: string;
+}) => {
+  return await fetcher.post("/auth/signup/oauth", body);
+};
+
 export const getIssues = async () => {
   return await fetcherWithBearer.get<IssueItem[]>("/issues");
 };

--- a/fe/src/components/Auth/GitHubLoginButton.tsx
+++ b/fe/src/components/Auth/GitHubLoginButton.tsx
@@ -1,0 +1,15 @@
+import Button from "@components/common/Button";
+
+export default function GitHubLoginButton() {
+  const gitHubCredentialsLink = `https://github.com/login/oauth/authorize?client_id=${
+    import.meta.env.GITHUB_CLIENT_ID
+  }&allow_signup=false&scope=read:user,user:email`;
+
+  return (
+    <a href={gitHubCredentialsLink}>
+      <Button variant="outline" size="XL" className="github-login-btn">
+        GitHub 계정으로 로그인
+      </Button>
+    </a>
+  );
+}

--- a/fe/src/hooks/useInput.tsx
+++ b/fe/src/hooks/useInput.tsx
@@ -20,7 +20,7 @@ export default function useInput({
   };
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const targetValue = e.target.value;
+    const targetValue = e.target.value.trim();
     validate(targetValue);
   };
 

--- a/fe/src/mocks/handlers.ts
+++ b/fe/src/mocks/handlers.ts
@@ -78,6 +78,44 @@ export const handlers = [
     );
   }),
 
+  rest.get("/api/auth/login/oauth", async (_, res, ctx) => {
+    // 최초 로그인인 경우
+    return res(ctx.status(202), ctx.json({ email: "email@email.com" }));
+
+    // 최초 로그인이 아닌 경우
+    // return res(
+    //   ctx.status(200),
+    //   ctx.json({
+    //     token: {
+    //       tokenType: "bearer",
+    //       accessToken: "q13t302hv2ht0",
+    //       expirationTime: 1791720452298,
+    //     },
+    //     user: {
+    //       username: "username",
+    //       profileUrl: "https://avatars.githubusercontent.com/u/48426991?v=4",
+    //     },
+    //   })
+    // );
+  }),
+
+  rest.post("/api/auth/signup/oauth", async (_, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        token: {
+          tokenType: "bearer",
+          accessToken: "q13t302hv2ht0",
+          expirationTime: 1791720452298,
+        },
+        user: {
+          username: "username",
+          profileUrl: "https://avatars.githubusercontent.com/u/48426991?v=4",
+        },
+      })
+    );
+  }),
+
   rest.get("/api/issues", async (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(issueList));
   }),

--- a/fe/src/pages/Auth/LoginPage.tsx
+++ b/fe/src/pages/Auth/LoginPage.tsx
@@ -1,10 +1,11 @@
+import GitHubLoginButton from "@components/Auth/GitHubLoginButton";
 import Button from "@components/common/Button";
 import TextInput from "@components/common/TextInput";
 import useInput from "@hooks/useInput";
-import { postLogin } from "api";
+import { getGitHubLogin, postLogin, postOAuthUsername } from "api";
 import { AxiosError } from "axios";
 import { useAuth } from "context/authContext";
-import { useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
@@ -20,16 +21,71 @@ export default function LoginPage() {
     minLength: 6,
   });
   const [errorMessage, setErrorMessage] = useState<string>("");
+  const [newOAuthUserEmail, setNewOAuthUserEmail] = useState<string | null>(
+    null
+  );
   const { onLogin } = useAuth();
   const navigate = useNavigate();
 
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  // GitHub Callback URL (임시토큰 접수)
+  useEffect(() => {
+    const gitHubLogin = async (code: string) => {
+      try {
+        const res = await getGitHubLogin(code);
+
+        if (res.status === 200) {
+          const { token, user } = res.data;
+          onLogin({
+            accessToken: token.accessToken,
+            userInfo: user,
+            expirationTime: token.expirationTime,
+          });
+          navigate("/");
+        } else if (res.status === 202) {
+          // GitHub을 통한 최초 로그인 (i.e. username 없음. 등록해야 회원가입 완료.)
+          const { email } = res.data;
+          setNewOAuthUserEmail(email);
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    const urlParams = new URLSearchParams(document.location.search);
+    const code = urlParams.get("code");
+    if (code) {
+      gitHubLogin(code);
+    }
+  });
+
+  const onOAuthUsernameSubmit = async (e: FormEvent) => {
     e.preventDefault();
 
     try {
-      const {
-        data: { token, user },
-      } = await postLogin(username.value, password.value);
+      const res = await postOAuthUsername({
+        username: username.value,
+        email: newOAuthUserEmail as string,
+      });
+      const { token, user } = res.data;
+      onLogin({
+        accessToken: token.accessToken,
+        userInfo: user,
+        expirationTime: token.expirationTime,
+      });
+      setNewOAuthUserEmail(null);
+      navigate("/");
+    } catch (error) {
+      // TODO
+      console.error(error);
+    }
+  };
+
+  const onIdPasswordLogin = async (e: FormEvent) => {
+    e.preventDefault();
+
+    try {
+      const res = await postLogin(username.value, password.value);
+      const { token, user } = res.data;
       onLogin({
         accessToken: token.accessToken,
         userInfo: user,
@@ -46,43 +102,67 @@ export default function LoginPage() {
 
   return (
     <>
-      <Button variant="outline" size="XL" className="github-login-btn">
-        GitHub 계정으로 로그인
-      </Button>
-      <span className="or">or</span>
-      <AuthForm onSubmit={onSubmit}>
-        <TextInput
-          name="아이디"
-          variant="tall"
-          hasError={!isValidUsername}
-          placeholder="아이디"
-          helpText="아이디는 최소 6자리여야 해요!"
-          {...username}
-        />
-        <TextInput
-          name="비밀번호"
-          variant="tall"
-          hasError={!isValidPassword}
-          placeholder="비밀번호"
-          helpText="비밀번호는 최소 6자리여야 해요!"
-          type="password"
-          {...password}
-        />
-        {errorMessage && <p className="error-message">{errorMessage}</p>}
-        <Button
-          variant="container"
-          size="XL"
-          className="login-btn"
-          disabled={!isValidUsername || !isValidPassword}
-          type="submit">
-          아이디로 로그인
-        </Button>
-      </AuthForm>
-      <Link to="/signup">
-        <Button variant="ghost" size="XL" className="change-auth-btn">
-          아직 계정이 없으신가요? 회원가입
-        </Button>
-      </Link>
+      {newOAuthUserEmail ? (
+        <AuthForm onSubmit={onOAuthUsernameSubmit}>
+          <span className="username-registration">
+            사용하실 아이디를 등록해주세요
+          </span>
+          <TextInput
+            name="아이디"
+            variant="tall"
+            hasError={!isValidUsername}
+            placeholder="아이디"
+            helpText="아이디는 최소 6자리여야 해요!"
+            {...username}
+          />
+          <Button
+            variant="container"
+            size="XL"
+            className="login-btn"
+            disabled={!isValidUsername}
+            type="submit">
+            아이디 등록
+          </Button>
+        </AuthForm>
+      ) : (
+        <>
+          <GitHubLoginButton />
+          <span className="or">or</span>
+          <AuthForm onSubmit={onIdPasswordLogin}>
+            <TextInput
+              name="아이디"
+              variant="tall"
+              hasError={!isValidUsername}
+              placeholder="아이디"
+              helpText="아이디는 최소 6자리여야 해요!"
+              {...username}
+            />
+            <TextInput
+              name="비밀번호"
+              variant="tall"
+              hasError={!isValidPassword}
+              placeholder="비밀번호"
+              helpText="비밀번호는 최소 6자리여야 해요!"
+              type="password"
+              {...password}
+            />
+            {errorMessage && <p className="error-message">{errorMessage}</p>}
+            <Button
+              variant="container"
+              size="XL"
+              className="login-btn"
+              disabled={!isValidUsername || !isValidPassword}
+              type="submit">
+              아이디로 로그인
+            </Button>
+          </AuthForm>
+          <Link to="/signup">
+            <Button variant="ghost" size="XL" className="change-auth-btn">
+              아직 계정이 없으신가요? 회원가입
+            </Button>
+          </Link>
+        </>
+      )}
     </>
   );
 }
@@ -90,8 +170,14 @@ export default function LoginPage() {
 export const AuthForm = styled.form`
   display: flex;
   flex-direction: column;
+  align-items: center;
   width: 100%;
   gap: 12px;
+
+  .username-registration {
+    font: ${({ theme: { font } }) => font.displayMD16};
+    color: ${({ theme: { neutral } }) => neutral.text.default};
+  }
 
   .login-btn {
     font: ${({ theme: { font } }) => font.availableMD20};


### PR DESCRIPTION
## Issues
- #156 

## What is this PR? 👓
- GitHub OAuth 기능 구현.

## Key changes 🔑
- GitHubLoginButton 구현.
- LoginPage를 Callback URL로 등록해놔서 `useEffect`로 url params에 `code` 여부를 확인해서 있으면 서버로 보내는 방식입니다.

## To reviewers 👋
- [슬랙 스레드](https://codesquad-members.slack.com/archives/C05K20TCKME/p1692276631933159?thread_ts=1692266068.934139&cid=C05K20TCKME)에 정리한 흐름대로 구현했습니다.
- 일단 `fe-w4` 브랜치를 AWS Amplify에 [배포](https://fe-w4.d2kit8rai80g4y.amplifyapp.com)해놨고 (이 PR이 아직 fe-w4에 없고) 배포된 앱을 GitHub OAuth Client로 등록해놔서 개발환경에서 시도는 못해봤습니다. 그리고 서버 SSL Error 해결되고 확인 가능할것 같습니다.
- `fe-w4`에 머지하고 데모전 오전에 얼른 확인해봐야할 것 같습니다.
