### PR TITLE
[BE] 이슈 카운트 쿼리 수정, 이미지 리사이징 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.518'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.518'
 
+    // image
+    implementation 'net.coobird:thumbnailator:0.4.19'
+    testImplementation 'net.coobird:thumbnailator:0.4.19'
+
     // mock web server
     testImplementation 'com.squareup.okhttp3:okhttp:4.0.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.0.1'

--- a/backend/src/main/java/kr/codesquad/issuetracker/application/S3Service.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/application/S3Service.java
@@ -1,11 +1,23 @@
 package kr.codesquad.issuetracker.application;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Objects;
+
+import javax.imageio.ImageIO;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import net.coobird.thumbnailator.Thumbnails;
+
 import kr.codesquad.issuetracker.application.s3.S3Uploader;
 import kr.codesquad.issuetracker.domain.ImageFile;
+import kr.codesquad.issuetracker.exception.ApplicationException;
+import kr.codesquad.issuetracker.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -19,6 +31,23 @@ public class S3Service {
 	@Transactional
 	public String uploadImage(MultipartFile file) {
 		ImageFile imageFile = ImageFile.from(file);
+
+		BufferedImage bufferedImage;
+		BufferedImage resizedImage;
+		try {
+			bufferedImage = ImageIO.read(file.getInputStream());
+			if (Math.max(bufferedImage.getWidth(), bufferedImage.getHeight()) > 800) {
+				resizedImage = Thumbnails.of(bufferedImage)
+					.size(800, 800).asBufferedImage();
+				ByteArrayOutputStream output = new ByteArrayOutputStream();
+				ImageIO.write(resizedImage, Objects.requireNonNull(file.getContentType()).split("/")[1], output);
+				ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray());
+				imageFile = new ImageFile(file.getOriginalFilename(), file.getContentType(), input,
+					(long)output.toByteArray().length);
+			}
+		} catch (IOException e) {
+			throw new ApplicationException(ErrorCode.NON_IMAGE_FILE);
+		}
 
 		// 버킷에 저장할 파일 이름 생성
 		String fileName = UPLOADED_IMAGES_DIR + imageFile.getRandomName();

--- a/backend/src/main/java/kr/codesquad/issuetracker/exception/ErrorCode.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 	// File
 	EMPTY_FILE(400, "파일이 없습니다."),
 	FILE_INVALID(400, "파일이 유효하지 않습니다."),
+	NON_IMAGE_FILE(400, "이미지 파일이 아닙니다."),
 	INVALID_FILE_EXTENSION(400, "지원하지 않는 파일 확장자입니다."),
 	FILE_IO_EXCEPTION(500, "파일 입출력에 실패했습니다."),
 

--- a/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/mapper/IssueCountMapper.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/infrastructure/persistence/mapper/IssueCountMapper.java
@@ -10,8 +10,6 @@ public class IssueCountMapper {
 
 	private int totalCounts;
 	private int openCounts;
+	private int closedCounts;
 
-	public int getClosedCounts() {
-		return totalCounts - openCounts;
-	}
 }

--- a/backend/src/main/java/kr/codesquad/issuetracker/presentation/FileController.java
+++ b/backend/src/main/java/kr/codesquad/issuetracker/presentation/FileController.java
@@ -18,11 +18,10 @@ import lombok.RequiredArgsConstructor;
 @RestController
 public class FileController {
 
-    private final S3Service s3Service;
+	private final S3Service s3Service;
 
-    // 이미지 업로드
-    @PostMapping("/images/upload")
-    public ResponseEntity<Map<String, String>> uploadImage(@RequestPart MultipartFile image) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("fileUrl", s3Service.uploadImage(image)));
-    }
+	@PostMapping("/images/upload")
+	public ResponseEntity<Map<String, String>> uploadImage(@RequestPart MultipartFile image) {
+		return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("fileUrl", s3Service.uploadImage(image)));
+	}
 }

--- a/backend/src/main/resources/mapper/IssueMapper.xml
+++ b/backend/src/main/resources/mapper/IssueMapper.xml
@@ -33,6 +33,7 @@
     <resultMap id="countResultMap" type="issueCountMapper">
         <result property="totalCounts" column="total_counts"/>
         <result property="openCounts" column="open_counts"/>
+        <result property="closedCounts" column="closed_counts"/>
     </resultMap>
 
     <select id="findAll" resultMap="issueResultMap">
@@ -106,11 +107,18 @@
     </select>
 
     <select id="countAll" resultMap="countResultMap">
-        SELECT DISTINCT
-            COUNT(DISTINCT issue.id) as total_counts,
-            COUNT(DISTINCT CASE WHEN issue.is_open = TRUE THEN issue.id ELSE NULL END) as open_counts
+        SELECT
+        COUNT(DISTINCT
+        CASE
+        WHEN #{issueSearch.isOpen} IS NULL THEN issue.id
+        WHEN #{issueSearch.isOpen} = TRUE AND issue.is_open = TRUE THEN issue.id
+        WHEN #{issueSearch.isOpen} = FALSE AND issue.is_open = FALSE THEN issue.id
+        ELSE NULL
+        END
+        ) as total_counts,
+        COUNT(DISTINCT CASE WHEN issue.is_open = TRUE THEN issue.id ELSE NULL END) as open_counts,
+        COUNT(DISTINCT CASE WHEN issue.is_open = FALSE THEN issue.id ELSE NULL END) as closed_counts
         FROM issue
-
         LEFT JOIN issue_label ON issue.id = issue_label.issue_id
         LEFT JOIN label ON label.id = issue_label.label_id AND label.is_deleted = false
         LEFT JOIN issue_assignee ON issue.id = issue_assignee.issue_id
@@ -122,9 +130,6 @@
         </if>
 
         WHERE issue.is_deleted = FALSE
-        <if test="issueSearch.isOpen != null">
-            AND issue.is_open = #{issueSearch.isOpen}
-        </if>
         <if test="issueSearch.milestoneName != null">
             AND milestone.name = #{issueSearch.milestoneName}
         </if>


### PR DESCRIPTION
## Issues
- #178 #179 

## What is this PR? 👓
- 이슈 카운트 수정
- 이미지 리사이징

## Key changes 🔑
- 이슈 카운트에서 is:open, is:closed 필터링이 적용되어도 상관 없이 open, closed 개수 카운트
- 이미지 사이즈가 800 넘어갈 시엔 리사이징하여 저장

## To reviewers 👋
- 쿼리 맞나..
- 사이즈 800 보다 큰 이미지 쓸 일 없을 것 같아 썸네일 처럼 따로 저장하지 않고 저 것만 저장했습니다.
- 리사이징에 Marvin 이라는 라이브러리를 많이 쓰던데.. 시간이 없어서 써봤던 Thumbnailator 를 썼습니다..
